### PR TITLE
Generate volatilityrc files to save current command line options (--save)

### DIFF
--- a/volatility/conf.py
+++ b/volatility/conf.py
@@ -273,7 +273,7 @@ class ConfObject(object):
                         v = getattr(opts, k)
                         if k in self.options and not v == None:
                             new_config.set('DEFAULT', str(k), str(self.opts[k]))
-                    ## Save command line options to ./volatilityrc
+                    ## Save command line options to save_location/volatilityrc or specified directory/filename
                     if os.path.isdir(save_location):
                         save_file = os.path.join(save_location, "volatilityrc")
                     else:


### PR DESCRIPTION
Hi all,
This contribution adds the ability to use --save or -s to save command line options such as PROFILE and LOCATION to a volatilityrc configuration file in the a specified directory.  When passed with plugins such as "imageinfo," both the plugin is run and the config file is generated.  When passed with --help, _only_ the help menu is displayed and no config is generated (the same way a module would not run if --help was passed).  If a filename is given (rather than a directory), that filename is used instead of volatilityrc.

Examples:
<code>vol.py -f /root/file1.vmem --profile=WinXPSP2x86 --tz GMT -s .</code>
*Generates a ./volatilityrc with profile, location, and tz saved

<code>vol.py -f /root/file1.vmem --profile=WinXPSP2x86 tz UTC --save /home/test/myrc pslist</code>
*Runs pslist, and generates a /home/test/myrc with profile and location saved

<code>python vol.py -f /root/file1.vmem -s . -h pslist</code>
*Only prints the help menu

The standard use will most likely be "-s ." because volatility will be looking for the current directory's volatilityrc.  If you have your memory images in different directories, this creates a conveniently portable config.
