### PR TITLE
Plugin to generate/modify configuration files

### DIFF
--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -66,7 +66,12 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
             print("Determining profile based on KDBG search...")
             self.suglist = [ s for s, _ in kdbgscan.KDBGScan.calculate(self)]
             if self.suglist:
-                self.new_config.set("DEFAULT", "profile", self.suglist[0])        ## Save current command line options first (these take precedence)
+                self.new_config.set("DEFAULT", "profile", self.suglist[0])
+                ## Update profile so --offsets will work
+                self._config.PROFILE = self.suglist[0]
+                self._exclude_options.append('profile')
+            else:
+                print("Failed to determine profile")
 
         ## Read in current command line (precedence over settings in configs)
         for key in self._config.opts:

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -65,7 +65,7 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
         self.save_location = self._config.DEST
 
     def set_comments(self, comments):
-        has_date = False
+        has_date = False  # Avoid making duplicate comments with Date
         new_comments = ""
         date_line = "# Date: " + str(datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
 
@@ -96,7 +96,6 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
                 for line in oldconfig:
                     if line.startswith("#"):
                         self.comments += line
-            print self.comments
 
 
         ## Attempt to automatically determine profile

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -29,7 +29,7 @@ class SaveConfig(common.AbstractWindowsCommand):
         common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
 
         config.add_option("DEST", default = "./volatilityrc", short_option = "D",
-            help = "Full path to save generated configuration file")
+            help = "File to save the generated configuration")
 
         config.add_option("EXCLUDE-CONF", default = False, short_option = "E",
             action = "store_true", help = "Exclude settings from configuration files")

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -19,10 +19,11 @@
 # along with Volatility.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import volatility.obj as obj
+#import volatility.obj as obj
 #import volatility.scan as scan
 #import volatility.cache as cache
 import volatility.plugins.common as common
+import volatility.conf as conf
 #import volatility.addrspace as addrspace
 #import volatility.registry as registry
 #import volatility.utils as utils
@@ -31,8 +32,15 @@ import ConfigParser
 #import os
 #import sys
 
+config = conf.ConfObject()
 
 class SaveConfig(common.AbstractWindowsCommand):
+
+    def __init__(self, config, *args, **kwargs):
+        config.add_option("SAVE-FILE", default = 'volatilityrc',
+            cache_invalidator = False, help = "User based configuration file")
+
+
     def calculate(self):
         
         new_config = ConfigParser.RawConfigParser()
@@ -47,3 +55,5 @@ class SaveConfig(common.AbstractWindowsCommand):
 
     def render_text(self, outfd, data):
         pass
+
+

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -74,11 +74,6 @@ class SaveConfig(common.AbstractWindowsCommand):
             max_key_width = max(len(str(key)), max_key_width)
             max_val_width = max(len(str(val)), max_val_width)
 
-        if max_key_width > 50:
-            max_key_width = 50
-        if max_val_width > 50:
-            max_val_width = 50
-
         return (str(max_key_width), str(max_val_width))
 
     def render_text(self, outfd, data):

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -71,10 +71,8 @@ class SaveConfig(common.AbstractWindowsCommand):
         max_val_width = 0
 
         for key, val in self.new_config.items("DEFAULT"):
-            if len(str(key)) > max_key_width:
-                max_key_width = len(str(key))
-            if len(str(val)) > max_val_width:
-                max_val_width = len(str(val))
+            max_key_width = max(len(str(key)), max_key_width)
+            max_val_width = max(len(str(val)), max_val_width)
 
         if max_key_width > 50:
             max_key_width = 50

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -32,7 +32,7 @@ class SaveConfig(common.AbstractWindowsCommand):
             help = "File to save the generated configuration")
 
         config.add_option("EXCLUDE-CONF", default = False, short_option = "E",
-            action = "store_true", help = "Exclude settings from configuration files")
+            action = "store_true", help = "Do not read options from configuration files")
 
         config.add_option("MODIFY", default = False, short_option = "M",
             action = "store_true", help = "Modify (rather than override) the generated configuration file")

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -27,7 +27,6 @@ import volatility.plugins.kdbgscan as kdbgscan
 import volatility.obj as obj
 import volatility.cache as cache
 import volatility.registry as registry
-
 import ConfigParser
 
 class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -54,7 +54,7 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
             action = "store_true", help = "Include current date/time comment in configuration file")
 
         ## Used to make sure we do not save our own options and options that are already saved
-        self._exclude_options = ["dest", "exclude_conf", "modify", "offsets", "auto"]
+        self._exclude_options = ["dest", "exclude_conf", "modify", "offsets", "auto", "date"]
         ## Used to store suggested profiles based on kdbg search
         self.suglist = []
         ## Store comments starting with '#'

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -135,7 +135,8 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
 
         ## Write the actual configuration file
         with open(self.save_location, "wb") as configfile:
-            configfile.write(self.comments)
+            if self.comments != "\n":
+                configfile.write(self.comments)
             self.new_config.write(configfile)
 
       #  self.put_date()

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -1,0 +1,49 @@
+# Volatility
+#
+# Authors:
+# Mike Auty <mike.auty@gmail.com>
+#
+# This file is part of Volatility.
+#
+# Volatility is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Volatility is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Volatility.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import volatility.obj as obj
+#import volatility.scan as scan
+#import volatility.cache as cache
+import volatility.plugins.common as common
+#import volatility.addrspace as addrspace
+#import volatility.registry as registry
+#import volatility.utils as utils
+#import volatility.exceptions as exceptions
+import ConfigParser
+#import os
+#import sys
+
+
+class SaveConfig(common.AbstractWindowsCommand):
+    def calculate(self):
+        
+        new_config = ConfigParser.RawConfigParser()
+        save_location = 'volatilityrc'
+        for key in self._config.cnf_opts:
+            print(key, self._config.cnf_opts[key])
+            new_config.set('DEFAULT', str(key), str(self._config.cnf_opts[key]))
+        
+        with open(save_location, 'wb') as configfile:
+            new_config.write(configfile)
+            print("Saved command line options to " + save_location)
+
+    def render_text(self, outfd, data):
+        pass

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -52,9 +52,16 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
         ## Used to make sure we do not save our own options and options that are already saved
         self._exclude_options = ["dest", "exclude_conf", "modify", "offsets", "auto"]
 
-    def calculate(self):
+        ## Used to store suggested profiles based on kdbg search
+        self.suglist = []
+
+        ## Used to save the generated configuration
         self.new_config = ConfigParser.RawConfigParser()
+
+        ## Where to output the generated configuration file
         self.save_location = self._config.DEST
+
+    def calculate(self):
 
         ## Read from existing target configuration (if modifying)
         if self._config.MODIFY:
@@ -92,11 +99,10 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
             if hasattr(addr_space, "dtb"):
                 self.new_config.set("DEFAULT", "dtb", str(hex(addr_space.dtb)))
 
-
-
         ## Write the actual configuration file
         with open(self.save_location, "wb") as configfile:
             self.new_config.write(configfile)
+
 
     def max_width(self):
         """ Return length of the longest key and longest value """

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -65,10 +65,27 @@ class SaveConfig(common.AbstractWindowsCommand):
         with open(self.save_location, "wb") as configfile:
             self.new_config.write(configfile)
 
+    def max_width(self):
+        """ Return length of the longest key and longest value """
+        max_key_width = 0
+        max_val_width = 0
+
+        for key, val in self.new_config.items("DEFAULT"):
+            if len(str(key)) > max_key_width:
+                max_key_width = len(str(key))
+            if len(str(val)) > max_val_width:
+                max_val_width = len(str(val))
+
+        if max_key_width > 50:
+            max_key_width = 50
+        if max_val_width > 50:
+            max_val_width = 50
+
+        return (str(max_key_width), str(max_val_width))
+
     def render_text(self, outfd, data):
         outfd.write("\n")
-        self.table_header(outfd, [("Option", "20"), ("Value", "75")])
-
+        self.table_header(outfd, [("Option", self.max_width()[0]), ("Value", self.max_width()[1])])
         ## Print out the final saved configuration
         for opt, val in self.new_config.items("DEFAULT"):
             self.table_row(outfd, opt, val)

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -38,23 +38,40 @@ class SaveConfig(common.AbstractWindowsCommand):
     def __init__(self, config, *args, **kwargs):
         common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
 
-        config.add_option("DEST", default = './volatilityrc',
-            cache_invalidator = False, help = "Destination of saved configuration file")
+        config.add_option("DEST", default = './volatilityrc', short_option = "D",
+            help = "Destination of saved configuration file")
 
+        config.add_option('EXCLUDE-CONF', default = False, short_option = "E",
+            action = "store_true", help = "Exclude settings from configuration files")
+
+        ## Used to make sure we don't save our own options
+        self._own_options = ["dest", "exclude_conf"]
 
     def calculate(self):
+        help( self._config)
         new_config = ConfigParser.RawConfigParser()
-        save_location = self._config.DEST
+        self.save_location = self._config.DEST
 
-        for key in self._config.cnf_opts:
-            yield key, self._config.cnf_opts[key]
-            new_config.set('DEFAULT', str(key), str(self._config.cnf_opts[key]))
+        ## Save options from configuration files
+        if self._config.EXCLUDE_CONF == False:
+            for key in self._config.cnf_opts:
+                yield key, self._config.cnf_opts[key]
+                new_config.set('DEFAULT', str(key), str(self._config.cnf_opts[key]))
 
-        with open(save_location, 'wb') as configfile:
+
+        ## Save current command line options
+        for key in self._config.opts:
+            if key not in self._own_options:
+                yield key, self._config.opts[key]
+                new_config.set('DEFAULT', str(key), str(self._config.opts[key]))
+
+        with open(self.save_location, 'wb') as configfile:
             new_config.write(configfile)
-            print("Saved command line options to " + save_location)
 
     def render_text(self, outfd, data):
+        outfd.write("\n")
+        self.table_header(outfd, [("Option", "20"), ("Value", "75")])
         for option in data:
-            outfd.write("{0}={1}\n".format(option[0],option[1]))
-
+            self.table_row(outfd, str(option[0]), str(option[1]))
+            #outfd.write("{0}\t=\t{1}\n".format(option[0], option[1]))
+        outfd.write("\nConfiguration saved to {}\n".format(self.save_location))

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -29,7 +29,7 @@ class SaveConfig(common.AbstractWindowsCommand):
         common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
 
         config.add_option("DEST", default = "./volatilityrc", short_option = "D",
-            help = "Destination of saved configuration file")
+            help = "Full path to save generated configuration file")
 
         config.add_option("EXCLUDE-CONF", default = False, short_option = "E",
             action = "store_true", help = "Exclude settings from configuration files")

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -38,19 +38,23 @@ class SaveConfig(common.AbstractWindowsCommand):
     def __init__(self, config, *args, **kwargs):
         common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
 
-        config.add_option("SAVE-FILE", default = './volatilityrc',
-            cache_invalidator = False, help = "Saved configuration file")
+        config.add_option("DEST", default = './volatilityrc',
+            cache_invalidator = False, help = "Destination of saved configuration file")
 
 
     def calculate(self):
         new_config = ConfigParser.RawConfigParser()
-        save_location = self._config.SAVE_FILE
+        save_location = self._config.DEST
 
         for key in self._config.cnf_opts:
-            print(key, self._config.cnf_opts[key])
+            yield key, self._config.cnf_opts[key]
             new_config.set('DEFAULT', str(key), str(self._config.cnf_opts[key]))
 
         with open(save_location, 'wb') as configfile:
             new_config.write(configfile)
             print("Saved command line options to " + save_location)
+
+    def render_text(self, outfd, data):
+        for option in data:
+            outfd.write("{0}={1}\n".format(option[0],option[1]))
 

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -37,7 +37,7 @@ class SaveConfig(common.AbstractWindowsCommand):
         config.add_option("MODIFY", default = False, short_option = "M",
             action = "store_true", help = "Modify (rather than override) the generated configuration file")
 
-        ## Used to make sure we don"t save our own options and options that are already saved
+        ## Used to make sure we do not save our own options and options that are already saved
         self._exclude_options = ["dest", "exclude_conf", "modify"]
 
     def calculate(self):
@@ -52,7 +52,7 @@ class SaveConfig(common.AbstractWindowsCommand):
         for key in self._config.opts:
             if key not in self._exclude_options:
                 self.new_config.set("DEFAULT", key, self._config.opts[key])
-                ## Add to excluded list so we don"t overwrite them later
+                ## Add to excluded list so we do not overwrite them later
                 self._exclude_options.append(key)
 
         ## Save options from configuration files (unless excluded by user)

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -32,28 +32,25 @@ import ConfigParser
 #import os
 #import sys
 
-config = conf.ConfObject()
 
 class SaveConfig(common.AbstractWindowsCommand):
 
     def __init__(self, config, *args, **kwargs):
-        config.add_option("SAVE-FILE", default = 'volatilityrc',
-            cache_invalidator = False, help = "User based configuration file")
+        common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
+
+        config.add_option("SAVE-FILE", default = './volatilityrc',
+            cache_invalidator = False, help = "Saved configuration file")
 
 
     def calculate(self):
-        
         new_config = ConfigParser.RawConfigParser()
-        save_location = 'volatilityrc'
+        save_location = self._config.SAVE_FILE
+
         for key in self._config.cnf_opts:
             print(key, self._config.cnf_opts[key])
             new_config.set('DEFAULT', str(key), str(self._config.cnf_opts[key]))
-        
+
         with open(save_location, 'wb') as configfile:
             new_config.write(configfile)
             print("Saved command line options to " + save_location)
-
-    def render_text(self, outfd, data):
-        pass
-
 

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -117,4 +117,9 @@ class SaveConfig(kdbgscan.KDBGScan): # common.AbstractWindowsCommand):
         for opt, val in self.new_config.items("DEFAULT"):
             self.table_row(outfd, opt, val)
 
+        if len(self.suglist) > 1:
+            outfd.write("\nSuggested profiles: {}\n".format(", ".join(self.suglist)))
+        if self.suglist:
+            outfd.write("Selected profile: {}\n".format(self.suglist[0]))
+
         outfd.write("\nConfiguration saved to {}\n".format(self.save_location))

--- a/volatility/plugins/saveconfig.py
+++ b/volatility/plugins/saveconfig.py
@@ -3,7 +3,7 @@
 # Author:
 # Andrew Cook <cooka2011@gmail.com>
 #
-# This file is part of Volatility.
+# This file is part of Volatility./
 #
 # Volatility is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,16 +28,16 @@ class SaveConfig(common.AbstractWindowsCommand):
     def __init__(self, config, *args, **kwargs):
         common.AbstractWindowsCommand.__init__(self, config, *args, **kwargs)
 
-        config.add_option("DEST", default = './volatilityrc', short_option = "D",
+        config.add_option("DEST", default = "./volatilityrc", short_option = "D",
             help = "Destination of saved configuration file")
 
-        config.add_option('EXCLUDE-CONF', default = False, short_option = "E",
+        config.add_option("EXCLUDE-CONF", default = False, short_option = "E",
             action = "store_true", help = "Exclude settings from configuration files")
 
-        config.add_option('MODIFY', default = False, short_option = "M",
+        config.add_option("MODIFY", default = False, short_option = "M",
             action = "store_true", help = "Modify (rather than override) the generated configuration file")
 
-        ## Used to make sure we don't save our own options and options that are already saved
+        ## Used to make sure we don"t save our own options and options that are already saved
         self._exclude_options = ["dest", "exclude_conf", "modify"]
 
     def calculate(self):
@@ -51,25 +51,26 @@ class SaveConfig(common.AbstractWindowsCommand):
         ## Save current command line options first (these take precedence)
         for key in self._config.opts:
             if key not in self._exclude_options:
-                self.new_config.set('DEFAULT', key, self._config.opts[key])
-                ## Add to excluded list so we don't overwrite them later
+                self.new_config.set("DEFAULT", key, self._config.opts[key])
+                ## Add to excluded list so we don"t overwrite them later
                 self._exclude_options.append(key)
 
         ## Save options from configuration files (unless excluded by user)
         if self._config.EXCLUDE_CONF == False:
             for key in self._config.cnf_opts:
                 if key not in self._exclude_options:
-                    self.new_config.set('DEFAULT', key, self._config.cnf_opts[key])
+                    self.new_config.set("DEFAULT", key, self._config.cnf_opts[key])
 
         ## Write the actual configuration file
-        with open(self.save_location, 'wb') as configfile:
+        with open(self.save_location, "wb") as configfile:
             self.new_config.write(configfile)
 
     def render_text(self, outfd, data):
         outfd.write("\n")
         self.table_header(outfd, [("Option", "20"), ("Value", "75")])
 
-        for opt, val in self.new_config.items('DEFAULT'):
+        ## Print out the final saved configuration
+        for opt, val in self.new_config.items("DEFAULT"):
             self.table_row(outfd, opt, val)
 
         outfd.write("\nConfiguration saved to {}\n".format(self.save_location))


### PR DESCRIPTION
Second attempt at #80.  This plugin reads the current options from command line and configuration files to generate or modify a configuration file.  Does this qualify for your plugin contest?

-D ./volatilityrc, --dest=./volatilityrc:     File to save the generated configuration
-E, --exclude-conf:   Do not read options from configuration files
-M, --modify:    Modify (rather than override) the generated configuration file
--auto:  Attempt to automatically determine profile
--offsets:  Get offsets, like KDBG and DTB

Save LOCATION, PROFILE and settings from other configs (eg /etc/volatilityrc) to ./volatilityrc:
<code>vol.py saveconfig -f /root/file1.vmem --tz UTC --profile WinXPSP2x86 </code>

Add TZ to preexisting ./volatilityrc (or create it):
<code>vol.py saveconfig -M --tz UTC</code>

Save LOCATION, PROFILE to /etc/volatilityrc (excluding other configuration settings):
<code>vol.py saveconfig -f /root/file1.vmem --tz UTC --profile WinXPSP2x86 -E -D /etc/volatilityrc</code>

Sample Output
![sampleoutput](https://cloud.githubusercontent.com/assets/4010275/4108778/6f297b20-31dc-11e4-879b-107eda8a1ca6.PNG)
