### PR TITLE
A few speedups

### DIFF
--- a/volatility/plugins/addrspaces/amd64.py
+++ b/volatility/plugins/addrspaces/amd64.py
@@ -68,14 +68,7 @@ class AMD64PagedMemory(paged.AbstractWritablePagedMemory):
 
     def entry_present(self, entry):
         if entry:
-            if (entry & 1):
-                return True
-
-            # The page is in transition and not a prototype.
-            # Thus, we will treat it as present.
-            if (entry & (1 << 11)) and not (entry & (1 << 10)):
-                return True
-
+            return (entry & 1) or ((entry & 2048) and not(entry & 1024))
         return False
 
     def page_size_flag(self, entry):

--- a/volatility/plugins/addrspaces/amd64.py
+++ b/volatility/plugins/addrspaces/amd64.py
@@ -64,6 +64,7 @@ class AMD64PagedMemory(paged.AbstractWritablePagedMemory):
     paging_address_space = True
     minimum_size = 0x1000
     alignment_gcd = 0x1000
+    ltQstruct = struct.Struct('<Q')
 
     def entry_present(self, entry):
         if entry:
@@ -208,7 +209,7 @@ class AMD64PagedMemory(paged.AbstractWritablePagedMemory):
             string = None
         if not string:
             return obj.NoneObject("Unable to read_long_long_phys at " + hex(addr))
-        (longlongval,) = struct.unpack('<Q', string)
+        longlongval, = ltQstruct.unpack(string)
         return longlongval
 
     def get_available_pages(self):

--- a/volatility/plugins/addrspaces/standard.py
+++ b/volatility/plugins/addrspaces/standard.py
@@ -83,6 +83,7 @@ class FileAddressSpace(addrspace.BaseAddressSpace):
         self.fhandle = open(self.fname, self.mode)
         self.fhandle.seek(0, 2)
         self.fsize = self.fhandle.tell()
+        self.eqIstruct = struct.Struct("=I")
 
     # Abstract Classes cannot register options, and since this checks config.WRITE in __init__, we define the option here
     @staticmethod
@@ -95,27 +96,21 @@ class FileAddressSpace(addrspace.BaseAddressSpace):
         return self.fhandle.read(length)
 
     def read(self, addr, length):
-        addr, length = int(addr), int(length)
         try:
             self.fhandle.seek(addr)
         except (IOError, OverflowError):
-            return None
-        data = self.fhandle.read(length)
-        if len(data) == 0:
-            return None
-        return data
+            return ""
+        return self.fhandle.read(length)
 
     def zread(self, addr, length):
         data = self.read(addr, length)
-        if data is None:
-            data = "\x00" * length
-        elif len(data) != length:
+        if len(data) != length:
             data += "\x00" * (length - len(data))
         return data
 
     def read_long(self, addr):
         string = self.read(addr, 4)
-        (longval,) = struct.unpack('=I', string)
+        longval, = self.eqIstruct.unpack(string)
         return longval
 
     def get_available_addresses(self):

--- a/volatility/plugins/addrspaces/standard.py
+++ b/volatility/plugins/addrspaces/standard.py
@@ -92,7 +92,7 @@ class FileAddressSpace(addrspace.BaseAddressSpace):
                           help = "Enable write support", callback = write_callback)
 
     def fread(self, length):
-        length = int(length)
+        #length = int(length) # unnecesary "cast"
         return self.fhandle.read(length)
 
     def read(self, addr, length):
@@ -119,7 +119,7 @@ class FileAddressSpace(addrspace.BaseAddressSpace):
         yield (0, self.fsize)
 
     def is_valid_address(self, addr):
-        if addr == None:
+        if addr is None: # is None is faster than == None
             return False
         return 0 <= addr < self.fsize
 


### PR DESCRIPTION
Instead of building buff from successive concatenations (which result in a lot of memory-to-memory writes), buff is build as a list of strings, which is concatenated once when the functions returns.
 In _read() intensive plugins, or when reading large chunks of data, this results in noticeable speedup.

The second and third most important changes are get_available_pages() and read_long_long_phys() in the AMD64 Addressspace.

All this changes should improve volatility's performance in different situations. Plugins or runs of volatility that don't require intensive access to the disk may not show significant improvements.