### PR TITLE
Fix endianness dependency in IpAddress

### DIFF
--- a/volatility/plugins/overlays/basic.py
+++ b/volatility/plugins/overlays/basic.py
@@ -156,10 +156,10 @@ class IpAddress(obj.NativeType):
     """Provides proper output for IpAddress objects"""
 
     def __init__(self, theType, offset, vm, **kwargs):
-        obj.NativeType.__init__(self, theType, offset, vm, format_string = vm.profile.native_types['unsigned int'][1], **kwargs)
+        obj.NativeType.__init__(self, theType, offset, vm, format_string = "4s", **kwargs)
 
     def v(self):
-        return utils.inet_ntop(socket.AF_INET, struct.pack("<I", obj.NativeType.v(self)))
+        return utils.inet_ntop(socket.AF_INET, obj.NativeType.v(self))
 
 class Ipv6Address(obj.NativeType):
     """Provides proper output for Ipv6Address objects"""


### PR DESCRIPTION
Current implementation byte swaps while reading the native
type, then byte swaps to convert to network order for inet_ntop
on little endian targets.

For big endian address spaces, this could would produce
incorrect results, as the native type would be in network byte
order, causing the struct.pack to mess up the IP address.

This aligns the conversion like it's done for IPv6 addresses.
