### PR TITLE
Malfind : added -A, -C & modified -W

### DIFF
--- a/volatility/plugins/malware/malfind.py
+++ b/volatility/plugins/malware/malfind.py
@@ -174,6 +174,10 @@ class YaraScan(taskmods.DllList):
 
     def __init__(self, config, *args, **kwargs):
         taskmods.DllList.__init__(self, config, *args, **kwargs)
+        config.add_option("ALL", short_option = 'A', default = False, action = 'store_true',
+                        help = 'Scan both process and kernel memory')                
+        config.add_option("CASE", short_option = 'C', default = False, action = 'store_true',
+                        help = 'Make the search case insensitive')        
         config.add_option("KERNEL", short_option = 'K', default = False, action = 'store_true',
                         help = 'Scan kernel modules')
         config.add_option("WIDE", short_option = 'W', default = False, action = 'store_true',
@@ -207,8 +211,10 @@ class YaraScan(taskmods.DllList):
                 s = self._config.YARA_RULES
                 # Don't wrap hex or regex rules in quotes 
                 if s[0] not in ("{", "/"): s = '"' + s + '"'
-                # Scan for unicode strings 
-                if self._config.WIDE: s += "wide"
+                # Option for case insensitive searches
+                if self._config.CASE: s += " nocase"
+                # Scan for unicode and ascii strings 
+                if self._config.WIDE: s += " wide ascii"
                 rules = yara.compile(sources = {
                             'n' : 'rule r1 {strings: $a = ' + s + ' condition: $a}'
                             })
@@ -221,69 +227,79 @@ class YaraScan(taskmods.DllList):
             
         return rules
 
-    def calculate(self):
+    def _scan_process_memory(self, addr_space, rules):
+        for task in self.filter_tasks(tasks.pslist(addr_space)):
+            scanner = VadYaraScanner(task = task, rules = rules)
+            for hit, address in scanner.scan():
+                yield (task, address, hit, scanner.address_space.zread(address - self._config.REVERSE, self._config.SIZE))
 
+    def _scan_kernel_memory(self, addr_space, rules):
+        # Find KDBG so we know where kernel memory begins. Do not assume
+        # the starting range is 0x80000000 because we may be dealing with
+        # an image with the /3GB boot switch. 
+        kdbg = tasks.get_kdbg(addr_space)
+
+        start = kdbg.MmSystemRangeStart.dereference_as("Pointer")
+
+        # Modules so we can map addresses to owners
+        mods = dict((addr_space.address_mask(mod.DllBase), mod)
+                    for mod in modules.lsmod(addr_space))
+        mod_addrs = sorted(mods.keys())
+
+        # There are multiple views (GUI sessions) of kernel memory.
+        # Since we're scanning virtual memory and not physical, 
+        # all sessions must be scanned for full coverage. This 
+        # really only has a positive effect if the data you're
+        # searching for is in GUI memory. 
+        sessions = []
+
+        for proc in tasks.pslist(addr_space):
+            sid = proc.SessionId
+            # Skip sessions we've already seen 
+            if sid == None or sid in sessions:
+                continue
+
+            session_space = proc.get_process_address_space()
+            if session_space == None:
+                continue
+
+            sessions.append(sid)
+            scanner = DiscontigYaraScanner(address_space = session_space,
+                                           rules = rules)
+
+            for hit, address in scanner.scan(start_offset = start):
+                module = tasks.find_module(mods, mod_addrs, addr_space.address_mask(address))
+                yield (module, address, hit, session_space.zread(address - self._config.REVERSE, self._config.SIZE))  
+
+    def calculate(self):
         if not has_yara:
             debug.error("Please install Yara from https://plusvic.github.io/yara/")
 
         addr_space = utils.load_as(self._config)
-
         rules = self._compile_rules()
+        process_mem = self._scan_process_memory(addr_space, rules)
+        kernel_mem = self._scan_kernel_memory(addr_space, rules)
 
-        if self._config.KERNEL:
-
-            # Find KDBG so we know where kernel memory begins. Do not assume
-            # the starting range is 0x80000000 because we may be dealing with
-            # an image with the /3GB boot switch. 
-            kdbg = tasks.get_kdbg(addr_space)
-
-            start = kdbg.MmSystemRangeStart.dereference_as("Pointer")
-
-            # Modules so we can map addresses to owners
-            mods = dict((addr_space.address_mask(mod.DllBase), mod)
-                        for mod in modules.lsmod(addr_space))
-            mod_addrs = sorted(mods.keys())
-
-            # There are multiple views (GUI sessions) of kernel memory.
-            # Since we're scanning virtual memory and not physical, 
-            # all sessions must be scanned for full coverage. This 
-            # really only has a positive effect if the data you're
-            # searching for is in GUI memory. 
-            sessions = []
-
-            for proc in tasks.pslist(addr_space):
-                sid = proc.SessionId
-                # Skip sessions we've already seen 
-                if sid == None or sid in sessions:
-                    continue
-
-                session_space = proc.get_process_address_space()
-                if session_space == None:
-                    continue
-
-                sessions.append(sid)
-                scanner = DiscontigYaraScanner(address_space = session_space,
-                                               rules = rules)
-
-                for hit, address in scanner.scan(start_offset = start):
-                    module = tasks.find_module(mods, mod_addrs, addr_space.address_mask(address))
-                    yield (module, address, hit, session_space.zread(address - self._config.REVERSE, self._config.SIZE))
-
+        if self._config.ALL:
+            for p in process_mem:
+                yield p
+            for k in kernel_mem:
+                yield k
+        elif self._config.KERNEL:
+            for k in kernel_mem:
+                yield k
         else:
-            for task in self.filter_tasks(tasks.pslist(addr_space)):
-                scanner = VadYaraScanner(task = task, rules = rules)
-                for hit, address in scanner.scan():
-                    yield (task, address, hit, scanner.address_space.zread(address - self._config.REVERSE, self._config.SIZE))
+            for p in process_mem:
+                yield p
 
     def render_text(self, outfd, data):
 
         if self._config.DUMP_DIR and not os.path.isdir(self._config.DUMP_DIR):
             debug.error(self._config.DUMP_DIR + " is not a directory")
-
         for o, addr, hit, content in data:
             outfd.write("Rule: {0}\n".format(hit.rule))
 
-            # Find out if the hit is from user or kernel mode 
+            # Find out if the hit is from user or kernel mode
             if o == None:
                 outfd.write("Owner: (Unknown Kernel Memory)\n")
                 filename = "kernel.{0:#x}.dmp".format(addr)
@@ -453,3 +469,4 @@ class LdrModules(taskmods.DllList):
                         outfd.write("  Init Path: {0} : {1}\n".format(init_mod.FullDllName, init_mod.BaseDllName))
                     if mem_mod:
                         outfd.write("  Mem Path:  {0} : {1}\n".format(mem_mod.FullDllName, mem_mod.BaseDllName))
+


### PR DESCRIPTION
Added:
~ '-C' for case insensitive YARA searches
~ '-A' for searching both process & kernel memory in one run of the plugin
~ '_scan_kernel_memory()' & '_scan_process_memory()' to YaraScan class due to the new '-A' switch

Modified:
~ '-W' now adds 'ascii' to YARA rule so both are searched when WIDE is chosen

single pull for https://github.com/volatilityfoundation/volatility/pull/131 ; easier this way
