### PR TITLE
added include timekeeper_internal.h for kernel >= 3.7 to linux/module.c

### DIFF
--- a/tools/linux/module.c
+++ b/tools/linux/module.c
@@ -404,6 +404,11 @@ struct slab slab;
 #endif
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,31)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
+/* Starting with Linux kernel 3.7 the struct timekeeper is defined in include/linux/timekeeper_internal.h */
+#include <linux/timekeeper_internal.h>
+#else
+/* Before Linux kernel 3.7 the struct timekeeper has to be taken from kernel/time/timekeeping.c */
 
 typedef u64 cycle_t;
 
@@ -465,6 +470,7 @@ struct timekeeper {
 	seqlock_t lock;
 };
 
+#endif
 
 struct timekeeper my_timekeeper;
 


### PR DESCRIPTION
https://github.com/volatilityfoundation/volatility/issues/162

In /tools/linux/module.c the struct timekeeper is defined.
This is from Linux kernel <= 3.6 kernel/time/timekeeping.c.
From Linux kernel 3.7 on the struct timekeeper is defined in include/linux/timekeeper_internal.h.

So I changed /tools/linux/module.c so that the struct struct timekeeper is only defined until kernel 3.6 and from kernel 3.7 on the timekeeper_internal.h is included.