### PR TITLE
Revert "Updated zeusscan to work with Volatility >= 2.3.1"

### DIFF
--- a/contrib/plugins/malware/zeusscan.py
+++ b/contrib/plugins/malware/zeusscan.py
@@ -201,7 +201,7 @@ class ZeusScan1(taskmods.DllList):
 # Scanner for Zeus >= 2.0 
 #--------------------------------------------------------------------------------
 
-class ZeusScan2(procdump.ProcExeDump):
+class ZeusScan2(procdump.ProcDump):
     """Locate and Decrypt Zeus >= 2.0 Configs"""
 
     signatures = {


### PR DESCRIPTION
Reverts volatilityfoundation/volatility#180

There is no procdump.ProcExeDump in version 2.4+