### PR TITLE
Update imagecopy.py to provide bytes copied stats

### DIFF
--- a/volatility/plugins/gui/vtypes/xp.py
+++ b/volatility/plugins/gui/vtypes/xp.py
@@ -157,7 +157,7 @@ class XP2003x86BaseVTypes(obj.ProfileModification):
             'right' : [ 0x8, ['long']],
             'bottom' : [ 0xc, ['long']],
             }],
-            'tagWND' : [ 0x90, {
+            'tagWND' : [ 0xA4, {
             'head' : [ 0x0, ['_THRDESKHEAD']],
             'ExStyle' : [ 0x1c, ['unsigned long']],
             'style' : [ 0x20, ['unsigned long']],


### PR DESCRIPTION
The original verison of imagecopy outputs a . (dot) per copied chunk. However, this output can be misleading/unhelpful. For example, when copying a hiberfil.sys, a chunk may be smaller than the indicated chunk size depending on the size of the run. As such, it is difficult for a user to know how much data has been copied and therefore to have a useful idea of progress. By using the new optional --count/-c switch, the plugin will report the number of bytes copied so far rather than dots. To aid efficiency, the update is only echoed to the screen after every BLOCKSIZE bytes have been copied.

Tested with raw images and hiberfil.sys files. Outputs checked to be the same by comparing the MD5 of the output with and without the --count/-c switch.

Note that the total number of bytes written does not necessarily equal the resulting file size. This is due to the way files like hiberfil.sys are stored and therefore uncompressed.