### PR TITLE
_vicinity_scan fixed

### DIFF
--- a/volatility/plugins/malware/impscan.py
+++ b/volatility/plugins/malware/impscan.py
@@ -157,8 +157,8 @@ class ImpScan(common.AbstractWindowsCommand):
                             vm = addr_space).v()
 
             if (not call_dest or
-                    call_dest < base_address or
-                    call_dest > base_address + data_len):
+                (call_dest > base_address and
+                 call_dest < base_address + data_len)):
                 threshold -= 1
                 i += 1
                 continue


### PR DESCRIPTION
As I reported before (issue #126), I checked the _vicinity_scan code and found a bug.
After the fix, the code worked fine.
For example, 

before fix:

$ python vol.py impscan --profile=Win7SP1x86 -f C:\dump\doridex_7x86.raw -p 1708
Volatility Foundation Volatility Framework 2.4
IAT      Call       Module       Function
0x337000 0x76e8431c ADVAPI32.dll GetTokenInformation
...skip...
0x337144 0x76bc6b0e WS2_32.dll   recv
0x339b74 0x75b133d3 kernel32.dll GetProcAddress
0x339b7c 0x75b1395c kernel32.dll LoadLibraryA

after fix:

$ python vol.py impscan --profile=Win7SP1x86 -f C:\dump\doridex_7x86.raw -p 1708
Volatility Foundation Volatility Framework 2.4
IAT      Call       Module       Function
0x337000 0x76e8431c ADVAPI32.dll GetTokenInformation
...skip...
0x337144 0x76bc6b0e WS2_32.dll   recv
0x339b74 0x75b133d3 kernel32.dll GetProcAddress
0x339b78 0x75b0cf41 kernel32.dll GetModuleHandleA    <-----  _vicinity_scan discovered API table successfully 
0x339b7c 0x75b1395c kernel32.dll LoadLibraryA

I can provide the sample memory image.
Please let me know if you have any question.