### PR TITLE
ignore fake RET

### DIFF
--- a/volatility/plugins/malware/apihooks.py
+++ b/volatility/plugins/malware/apihooks.py
@@ -835,9 +835,6 @@ class ApiHooks(procdump.ProcDump):
                         d = push_val
                         if outside_module(d):
                             break
-                    # This causes us to stop disassembling when 
-                    # reaching the end of a function 
-                    break
             n += 1
 
         # Check EIP after the function prologue 


### PR DESCRIPTION
I saw apihooks command sometimes drops inline hooks by malware. 
For example, SpyEye hooks HttpSendRequestA API for web injection like this:

76D518F8 > EB 01            JMP SHORT WININET.76D518FB
76D518FA   C3               RETN                        <-----   fake RET inserted (never executed)
76D518FB  -E9 3E117197      JMP 0E462A3E

apihooks is cheated by fake RET instruction.
I think the break I deleted is not needed because the routine set a limit of checking instructions by 'n' variable. I made sure the n was 0 to 2 even if I deleted the break.
Any thought? I can provide the malware sample.
