### PR TITLE
Added unified outputs and additionnal output info useful in finding some rootkits on Android

### DIFF
--- a/volatility/plugins/linux/kernel_opened_files.py
+++ b/volatility/plugins/linux/kernel_opened_files.py
@@ -22,12 +22,13 @@
 @author:       Andrew Case
 @license:      GNU General Public License 2.0
 @contact:      atcuno@gmail.com
-@organization: 
 """
 
 import volatility.obj as obj
 import volatility.plugins.linux.common as linux_common
 import volatility.plugins.linux.pslist as linux_pslist
+from volatility.renderers.basic import Address
+from volatility.renderers import TreeGrid
 
 class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
     """Lists files that are opened from within the kernel"""
@@ -35,7 +36,7 @@ class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
     def _walk_node_hash(self, node):
         last_node = None
         cnt = 0
-  
+
         hash_offset = self.addr_space.profile.get_obj_offset("dentry", "d_hash")
         while node.is_valid() and node != last_node:
             if cnt > 0:
@@ -45,11 +46,11 @@ class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
             cnt = cnt + 1
             last_node = node
             node = dentry.d_hash.next
-    
+
     def _walk_node_node(self, node):
         last_node = None
         cnt = 0
-  
+
         while node.is_valid() and node != last_node:
             if cnt > 0:
                 yield node, cnt
@@ -57,12 +58,12 @@ class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
             cnt = cnt + 1
             last_node = node
             node = node.next
-            
-    def _walk_node(self, node): 
+
+    def _walk_node(self, node):
         last_node = None
 
         yield node, 0
-        
+
         for node, cnt in self._walk_node_node(node):
             yield node, cnt
 
@@ -71,26 +72,26 @@ class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
 
     def _gather_dcache(self):
         d_hash_shift = obj.Object("unsigned int", offset =self.addr_space.profile.get_symbol("d_hash_shift"), vm = self.addr_space)
-        loop_max = 1 << d_hash_shift 
+        loop_max = 1 << d_hash_shift
 
         d_htable_ptr = obj.Object("Pointer", offset = self.addr_space.profile.get_symbol("dentry_hashtable"), vm = self.addr_space)
 
         arr = obj.Object(theType = "Array", targetType = "hlist_bl_head", offset = d_htable_ptr, vm = self.addr_space, count = loop_max)
 
         hash_offset = self.addr_space.profile.get_obj_offset("dentry", "d_hash")
-       
+
         dents = {}
 
         for list_head in arr:
             if not list_head.first.is_valid():
                 continue
 
-  
+
             node = obj.Object("hlist_bl_node", offset = list_head.first & ~1, vm = self.addr_space)
-            
-            for node, cnt in self._walk_node(node):   
+
+            for node, cnt in self._walk_node(node):
                 dents[node.v() - hash_offset] = 0
-    
+
         return dents
 
     def _compare_filps(self):
@@ -115,9 +116,18 @@ class linux_kernel_opened_files(linux_common.AbstractLinuxCommand):
         linux_common.set_plugin_members(self)
 
         for dentry_offset in self._compare_filps():
-            dentry = obj.Object("dentry", offset = dentry_offset, vm = self.addr_space) 
+            dentry = obj.Object("dentry", offset = dentry_offset, vm = self.addr_space)
             if dentry.d_count > 0 and dentry.d_inode.is_reg() and dentry.d_flags == 128:
                 yield dentry
+
+    def generator(self,data):
+        for dentry in data:
+            yield(0,Address(dentry.obj_offset),str(dentry.get_partial_path()))
+
+    def unified_output(self, data):
+        return TreeGrid([("Offset (V)",Address),
+                        ("Partial File Path",str)],
+                        self.generator(data))
 
     def render_text(self, outfd, data):
 

--- a/volatility/plugins/linux/lsof.py
+++ b/volatility/plugins/linux/lsof.py
@@ -21,33 +21,39 @@
 @author:       Andrew Case
 @license:      GNU General Public License 2.0
 @contact:      atcuno@gmail.com
-@organization: 
 """
 
-import volatility.obj as obj
+
+
 import volatility.plugins.linux.common as linux_common
 import volatility.plugins.linux.pslist as linux_pslist
+from volatility.renderers.basic import Address
 from volatility.renderers import TreeGrid
 
 class linux_lsof(linux_pslist.linux_pslist):
     """Lists file descriptors and their path"""
 
     def unified_output(self, data):
-        return TreeGrid([("Pid", int),
+        return TreeGrid([("Offset",Address),
+                         ("Name",str),
+                        ("Pid", int),
                        ("FD", int),
                        ("Path", str)],
                         self.generator(data))
 
     def generator(self, data):
         for task in data:
-            for filp, fd in task.lsof(): 
-                yield (0, [int(task.pid), int(fd), str(linux_common.get_path(task, filp))])
+            for filp, fd in task.lsof():
+                yield (0, [Address(task.obj_offset),str(task.comm),int(task.pid), int(fd), str(linux_common.get_path(task, filp))])
+
 
     def render_text(self, outfd, data):
-        self.table_header(outfd, [("Pid", "8"),
+        self.table_header(outfd, [("Offset","#018x"),
+                                  ("Name","30"),
+                                  ("Pid", "8"),
                                   ("FD", "8"),
                                   ("Path", "")])
 
         for task in data:
             for filp, fd in task.lsof(): 
-                self.table_row(outfd, task.pid, fd, linux_common.get_path(task, filp))
+                self.table_row(outfd, Address(task.obj_offset), str(task.comm), task.pid, fd, linux_common.get_path(task, filp))

--- a/volatility/plugins/linux/proc_maps.py
+++ b/volatility/plugins/linux/proc_maps.py
@@ -21,7 +21,6 @@
 @author:       Andrew Case
 @license:      GNU General Public License 2.0
 @contact:      atcuno@gmail.com
-@organization: 
 """
 
 import volatility.obj as obj
@@ -43,7 +42,9 @@ class linux_proc_maps(linux_pslist.linux_pslist):
                     yield task, vma            
 
     def unified_output(self, data):
-        return TreeGrid([("Pid", int),
+        return TreeGrid([("Offset",Address),
+                        ("Pid", int),
+                         ("Name",str),
                        ("Start", Address),
                        ("End", Address),
                        ("Flags", str),
@@ -58,7 +59,9 @@ class linux_proc_maps(linux_pslist.linux_pslist):
         for task, vma in data:
             (fname, major, minor, ino, pgoff) = vma.info(task)
 
-            yield (0, [int(task.pid),
+            yield (0, [Address(task.obj_offset),
+                       int(task.pid),
+                       str(task.comm),
                 Address(vma.vm_start),
                 Address(vma.vm_end),
                 str(vma.vm_flags),
@@ -69,7 +72,9 @@ class linux_proc_maps(linux_pslist.linux_pslist):
                 str(fname)])
 
     def render_text(self, outfd, data):
-        self.table_header(outfd, [("Pid", "8"),
+        self.table_header(outfd, [("Offset","#018x"),
+                                  ("Pid", "8"),
+                                  ("Name","20"),
                                   ("Start", "#018x"),
                                   ("End",   "#018x"),
                                   ("Flags", "6"),
@@ -82,7 +87,9 @@ class linux_proc_maps(linux_pslist.linux_pslist):
         for task, vma in data:
             (fname, major, minor, ino, pgoff) = vma.info(task)
 
-            self.table_row(outfd, task.pid, 
+            self.table_row(outfd, task.obj_offset,
+                task.pid,
+                task.comm,
                 vma.vm_start,
                 vma.vm_end,
                 str(vma.vm_flags),

--- a/volatility/plugins/linux/pstree.py
+++ b/volatility/plugins/linux/pstree.py
@@ -19,39 +19,65 @@
 @author:       Andrew Case
 @license:      GNU General Public License 2.0
 @contact:      atcuno@gmail.com
-@organization: 
 """
 
 import volatility.plugins.linux.pslist as linux_pslist
+from volatility.renderers.basic import Address
+from volatility.renderers import TreeGrid
+from collections import OrderedDict
 
 class linux_pstree(linux_pslist.linux_pslist):
     '''Shows the parent/child relationship between processes'''
 
     def __init__(self, *args, **kwargs):
         self.procs = {}
+        self.changed = True
         linux_pslist.linux_pslist.__init__(self, *args, **kwargs)
 
-    def render_text(self, outfd, data):
+    def unified_output(self, data):
+        return TreeGrid([("Offset",Address),
+                        ("Name",str),
+                        ("Level",str),
+                         ("Pid",int),
+                         ("Ppid",int),
+                            ("Uid", int),
+                            ("Gid",int),
+                            ("Euid",int)],
+                        self.generator(data))
 
-        self.procs = {}
-        outfd.write("{0:20s} {1:15s} {2:15s}\n".format("Name", "Pid", "Uid"))
+    def generator(self, data):
+        self.procs = OrderedDict()
         for task in data:
-            self.recurse_task(outfd, task, 0)
+            self.recurse_task(task, 0, 0,self.procs)
+            if self.changed:
+                for offset,name,level,pid,ppid,uid,euid,gid in self.procs.values():
+                    if offset:
+                        yield(0,[Address(offset),
+                                 str(name),
+                                 str(level),
+                                 int(pid),
+                                 int(ppid),
+                                 int(uid),
+                                 int(gid),
+                                 int(euid)])
 
-    def recurse_task(self, outfd, task, level):
-
-        if task.pid in self.procs:
-            return
-
-        if task.mm:
-            proc_name = task.comm
+    def recurse_task(self,task,ppid,level,procs):
+        """
+        Fill a dictionnary with all the children of a given task(including itself)
+        :param task: task that we want to get the children from
+        :param ppid: pid of the parent task
+        :param level: depth from the root task
+        :param procs: dictionnary that we fill
+        """
+        if not procs.has_key(task.pid):
+            self.changed = True
+            if task.mm:
+                proc_name = task.comm
+            else:
+                proc_name = "[" + task.comm + "]"
+            procs[task.pid] = (task.obj_offset,proc_name,"." * level + proc_name,task.pid,ppid,task.uid,task.euid,task.gid)
+            for child in task.children.list_of_type("task_struct", "sibling"):
+                self.recurse_task(child,task.pid, level + 1,procs)
         else:
-            proc_name = "[" + task.comm + "]"
-
-        proc_name = "." * level + proc_name
-        outfd.write("{0:20s} {1:15s} {2:15s}\n".format(proc_name, str(task.pid), str(task.uid or '')))
-        self.procs[task.pid] = 1
-
-        for child in task.children.list_of_type("task_struct", "sibling"):
-            self.recurse_task(outfd, child, level + 1)
+            self.changed = False
 

--- a/volatility/plugins/linux/threads.py
+++ b/volatility/plugins/linux/threads.py
@@ -21,18 +21,54 @@
 """
 
 import volatility.plugins.linux.pslist as linux_pslist
-import volatility.plugins.linux.common as linux_common
-import volatility.obj as obj
+from volatility.renderers.basic import Address
+from volatility.renderers import TreeGrid
 
 class linux_threads(linux_pslist.linux_pslist):
     """ Prints threads of processes """
-    
-    def render_text(self, outfd, data):
+
+    def unified_output(self, data):
+        return TreeGrid([("Offset",Address),
+                        ("NameProc",str),
+                         ("TGID",int),
+                         ("ThreadPid",str),
+                            ("ThreadName", str),
+                        ("thread_offset",Address),
+                            ("Addr_limit",Address),
+                            ("uid_cred",int),
+                            ("gid_cred",int),
+                            ("euid_cred",int)
+                        ],
+                        self.generator(data))
+
+    def generator(self, data):
+
         for task in data:
-            outfd.write("\nProcess Name: {}\nProcess ID: {}\n".format(task.comm, task.tgid))
-            self.table_header(outfd, [('Thread PID', '13'), ('Thread Name', '16')])
+            euidcred = task.euid
+            uidcred = task.uid
+            gidcred = task.gid
             for thread in task.threads():
-                self.table_row(outfd, str(thread.pid), thread.comm)
+                addr_limit = self.get_addr_limit(thread)
+                yield(0,[Address(task.obj_offset),
+                         str(task.comm),
+                         int(task.tgid),
+                         str(thread.pid),
+                         str(thread.comm),
+                         Address(thread.obj_offset),
+                         Address(addr_limit),
+                         int(uidcred),
+                         int(gidcred),
+                         int(euidcred)
+                ])
 
-
-
+    def get_addr_limit(self,thread, addrvar_offset = 8 ):
+        """
+        Here we read the addr_limit variable of a thread by reading at the offset of the thread plus
+        the offset of the addr_limit variable inside the thread_info
+        :param thread: thread from which we want the information
+        :param addrvar_offset: offset of the addr_limit var in the thread_info
+        :return: the addr_limit
+        """
+        addr_space = thread.get_process_address_space()
+        offset = thread.obj_offset + addrvar_offset
+        return addr_space.read_long_phys(offset)


### PR DESCRIPTION
Modifications :

linux_lsof : Added Offset column, allowing easier navigation in the raw memory file and Name Column, making it easier to identify which process is executing.
linux_proc_maps : Same thing
linux_pstree : Now outputs the various thread_info related information that could indicate if a Thread as unusual attributes (for instance, a Thread which has no Parent Process ID that could delegate root access but has a PID of 0 could indicate credentials tempering (as seen in Towelroot for instance).
linux_threads: Added thread_info outputs and also addr_limit which can be tempered with to allow writing anywhere in order to change kernel-related objects (again, as seen in Towelroot).

Also, each of these plugins have been modified in order to produce unified outputs.

Credits : @JonathanOuellet1275 and @martarek