### PR TITLE
dlldump: use name and extension of original mod_name for extracted file

### DIFF
--- a/volatility/plugins/dlldump.py
+++ b/volatility/plugins/dlldump.py
@@ -135,7 +135,7 @@ class DLLDump(procdump.ProcDump):
                 result = "Error: DllBase is paged"
             else:
                 process_offset = ps_ad.vtop(proc.obj_offset)
-                dump_file = "module.{0}.{1:x}.{2:x}.dll".format(proc.UniqueProcessId, process_offset, mod_base)
+                dump_file = "module.{0}.{1:x}.{2:09x}.{3}".format(proc.UniqueProcessId, process_offset, mod_base, str(mod_name or ''))
                 result = self.dump_pe(ps_ad, mod_base, dump_file)
             self.table_row(outfd,
                     proc.obj_offset,

--- a/volatility/plugins/vadinfo.py
+++ b/volatility/plugins/vadinfo.py
@@ -461,9 +461,17 @@ class VADDump(VADInfo):
                 vad_start = self.format_value(vad.Start, "[addrpad]")
                 vad_end = self.format_value(vad.End, "[addrpad]")
 
+                # if vad is file_object and has a FileName use it (replacing backslashes to underscores)
+                name=".dmp"
+                if vad.VadFlags.PrivateMemory != 1:
+                    control_area = vad.ControlArea
+                    if control_area:
+                        file_object = vad.FileObject
+			name=str(file_object.FileName or '').replace("\\","_")
+
                 path = os.path.join(
-                    self._config.DUMP_DIR, "{0}.{1:x}.{2}-{3}.dmp".format(
-                    task.ImageFileName, offset, vad_start, vad_end))
+                    self._config.DUMP_DIR, "{0}.{1:x}.{2}-{3}{4}".format(
+                    task.ImageFileName, offset, vad_start, vad_end,name ))
 
                 result = self.dump_vad(path, vad, task_space)
 


### PR DESCRIPTION
After this patch dlldump creates better filenames.

Old:

    Process(V) Name                 Module Base Module Name          Result
    ---------- -------------------- ----------- -------------------- ------
    0x856203e0 rundll32.exe         0x000ea0000 rundll32.exe         OK: module.3416.3f6203e0.ea0000.dll
    0x856203e0 rundll32.exe         0x076e10000 ntdll.dll            OK: module.3416.3f6203e0.76e10000.dll
    0x856203e0 rundll32.exe         0x075530000 OLEAUT32.dll         OK: module.3416.3f6203e0.75530000.dll
    0x856203e0 rundll32.exe         0x076f60000 sechost.dll          OK: module.3416.3f6203e0.76f60000.dll
    0x856203e0 rundll32.exe         0x0702c0000 WINSPOOL.DRV         OK: module.3416.3f6203e0.702c0000.dll

New:

    Process(V) Name                 Module Base Module Name          Result
    ---------- -------------------- ----------- -------------------- ------
    0x856203e0 rundll32.exe         0x000ea0000 rundll32.exe         OK: module.3416.3f6203e0.000ea0000.rundll32.exe
    0x856203e0 rundll32.exe         0x076e10000 ntdll.dll            OK: module.3416.3f6203e0.076e10000.ntdll.dll
    0x856203e0 rundll32.exe         0x075530000 OLEAUT32.dll         OK: module.3416.3f6203e0.075530000.OLEAUT32.dll
    0x856203e0 rundll32.exe         0x076f60000 sechost.dll          OK: module.3416.3f6203e0.076f60000.sechost.dll
    0x856203e0 rundll32.exe         0x0702c0000 WINSPOOL.DRV         OK: module.3416.3f6203e0.0702c0000.WINSPOOL.DRV

'Module Name' is used for result, including extension. 
Also leading zeros are not dismissed.