### PR TITLE
Fix exception when prev_op is None

### DIFF
--- a/volatility/plugins/linux/check_inline_kernel.py
+++ b/volatility/plugins/linux/check_inline_kernel.py
@@ -77,7 +77,7 @@ class linux_check_inline_kernel(linux_common.AbstractLinuxCommand):
                 addr = 0 # default in case we cannot extract               
 
                 # check for a mov reg, addr; jmp reg;
-                if prev_op.mnemonic == "MOV" and prev_op.operands[0].type == 'Register' and op.operands[0].type == 'Register':
+                if prev_op is not None and prev_op.mnemonic == "MOV" and prev_op.operands[0].type == 'Register' and op.operands[0].type == 'Register':
                     prev_name = prev_op.operands[0].name
                     
                     # same register


### PR DESCRIPTION
```
$ vol.py linux_check_inline_kernel > linux_check_inline_kernel.txt
Volatility Foundation Volatility Framework 2.4
Traceback (most recent call last):
  File "/usr/local/bin/vol.py", line 192, in <module>
    main()
  File "/usr/local/bin/vol.py", line 183, in main
    command.execute()
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/common.py", line 63, in execute
    commands.Command.execute(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/volatility/commands.py", line 145, in execute
    func(outfd, data)
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 319, in render_text
    for (sym_name, member, hook_type, sym_addr) in data:
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 299, in calculate
    for (sym_name, member, hook_type, sym_addr) in func(modules):
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 218, in _check_file_op_pointers
    for (name, member, hook_type, address) in func(f_op_members, modules):
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 135, in check_file_cache
    for (hooked_member, hook_type, hook_address) in self._is_inline_hooked(file_dentry.d_inode.i_fop, f_op_members, modules):
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 128, in _is_inline_hooked
    hook_info = self._is_hooked(addr, modules)
  File "/usr/local/lib/python2.7/dist-packages/volatility/plugins/linux/check_inline_kernel.py", line 80, in _is_hooked
    if prev_op.mnemonic == "MOV" and prev_op.operands[0].type == 'Register' and op.operands[0].type == 'Register':
AttributeError: 'NoneType' object has no attribute 'mnemonic'
```

Solution is to check if prev_op is None first. 
