### PR TITLE
Fixed vadinfo graphviz output coloring, missing filled style declaration

### DIFF
--- a/volatility/plugins/vadinfo.py
+++ b/volatility/plugins/vadinfo.py
@@ -333,7 +333,7 @@ class VADTree(VADInfo):
                             except AttributeError:
                                 pass                        
                         outfd.write("vad_{0:08x} [label = \"{{ {1}\\n{2:08x} - {3:08x} }}\""
-                                "shape = \"record\" color = \"blue\" fillcolor = \"{4}\"];\n".format(
+                                "shape = \"record\" style = \"filled\" color = \"blue\" fillcolor = \"{4}\"];\n".format(
                         vad.obj_offset,
                         vad.Tag,
                         vad.Start,


### PR DESCRIPTION
Fixed bug in vadinfo plugin. The Graphviz dot output function is writing out all of the fill colors, but by default fill colors are not applied to a Graphviz graph unless the "style = filled" declaration is provided.