### PR TITLE
editbox reports position and text of undo buffer.

### DIFF
--- a/volatility/plugins/gui/editbox.py
+++ b/volatility/plugins/gui/editbox.py
@@ -52,6 +52,9 @@ gdi_types_x86 = {
         'selStart': [0x14, ['unsigned long']],
         'selEnd': [0x18, ['unsigned long']],
         'pwdChar': [0x30, ['unsigned short']],
+        'undoBuf': [0x88, ['unsigned long']],
+        'undoPos': [0x8C, ['unsigned long']],
+        'undoLen': [0x90, ['unsigned long']],
         'bEncKeyXP': [0xEC, ['unsigned char']], # XP
         'bEncKey': [0xF4, ['unsigned char']] # Win7/2008R2
         # TODO: bEncKey is hacky. Should have diff types for each.
@@ -86,6 +89,9 @@ gdi_types_x64 = {
         'selStart': [0x18, ['unsigned long']],
         'selEnd': [0x20, ['unsigned long']],
         'pwdChar': [0x34, ['unsigned short']],
+        'undoBuf': [0xA8, ['unsigned long']],
+        'undoPos': [0xB0, ['unsigned long']],
+        'undoLen': [0xB4, ['unsigned long']],
         'bEncKey': [0x140, ['unsigned char']]
     } ],
     '_LISTBOX_x64': [ 0x100, {
@@ -294,6 +300,17 @@ class EditBox(messagehooks.MessageHooks):
             outfd.write('nChars               : {0} ({0:#x})\n'.format(editbox.nChars))
             outfd.write('selStart             : {0} ({0:#x})\n'.format(editbox.selStart))
             outfd.write('selEnd               : {0} ({0:#x})\n'.format(editbox.selEnd))
+            outfd.write('undoPos              : {0} ({0:#x})\n'.format(editbox.undoPos))
+            outfd.write('undoLen              : {0} ({0:#x})\n'.format(editbox.undoLen))
+
+            if editbox.undoBuf == 0:
+                outfd.write('address-of undoBuf   : undo-is-empty\n')
+                outfd.write('undoBuf[:100]        : undo-is-empty\n')
+            else:
+                outfd.write('address-of undoBuf   : {0:#x} [{1:#x}]\n'.format(
+                    editbox.undoBuf, task_space.vtop(editbox.undoBuf)))
+                outfd.write('undoBuf[:100]        : {0}\n'.format(
+                    editbox.obj_vm.read(editbox.undoBuf, 2 * editbox.undoLen)[:100]))
 
             if valid_hbuf:
                 outfd.write('text_md5             : {0}\n'.format(md5))


### PR DESCRIPTION
editbox now reports the text contained in the undo buffer of the Edit control and the position at which the text originally resided.

Sample output, "msn" was cut from the URL in Internet Explorer's address bar.
`undoPos`: where in the Edit control the text originally resided.
`undoLen`: the number of characters in the undo buffer.
`address-of undoBuf`: address of buffer (i.e. the text).
`undoBuf`: the text in the undo buffer. Only the first 100 bytes (50 characters) are reported, but full text can easily be found if needed by dumping `address-of undoBuf`.
```
*******************************************************
Wnd context          : 1\WinSta0\Default
pointer-to tagWND    : 0xfea11c20 [0x57b23c20]
pid                  : 2704
imageFileName        : iexplore.exe
atom_class           : 6.0.7601.17514!Edit
address-of cbwndExtra: 0xfea11cb0 [0x57b23cb0]
value-of cbwndExtra  : 4 (0x4)
address-of WndExtra  : 0xfea11cd0 [0x57b23cd0]
value-of WndExtra    : 0x396e68 [0x6dd7e68]
pointer-to hBuf      : 0x39d280 [0x4cba4280]
hWnd                 : 0x10168
parenthWnd           : 0x10162
nChars               : 32 (0x20)
selStart             : 0 (0x0)
selEnd               : 32 (0x20)
undoPos              : 11 (0xb)
undoLen              : 3 (0x3)
address-of undoBuf   : 0x5350310 [0x2f82a310]
undoBuf[:100]        : msn
text_md5             : e9f86e4ca8b0e8bd20a1948e76fdea81
isPwdControl         : No
http://www..com/en-gb/?ocid=iehp
*******************************************************
```