### PR TITLE
Fix lsmod and volshell modules() for kernels later than 3.9

### DIFF
--- a/volatility/plugins/linux/linux_volshell.py
+++ b/volatility/plugins/linux/linux_volshell.py
@@ -33,7 +33,10 @@ class linux_volshell(volshell.volshell):
         mods = lsmod.linux_lsmod(self._config).calculate()
 
         for (module, _, __) in mods:
-            print "{0:24} {1:d}".format(module.name, module.init_size + module.core_size)
+            if module.core_layout:
+                print "{0:24} {1:d}".format(module.name, module.core_layout.m('size'))
+            else:
+                print "{0:24} {1:d}".format(module.name, module.init_size + module.core_size)
 
     def getpidlist(self):
         return pslist.linux_pslist(self._config).allprocs()

--- a/volatility/plugins/linux/lsmod.py
+++ b/volatility/plugins/linux/lsmod.py
@@ -88,7 +88,10 @@ class linux_lsmod(linux_common.AbstractLinuxCommand):
 
                 fd.write("}")
 
-            outfd.write("{2:x} {0:s} {1:d}\n".format(module.name, module.init_size + module.core_size, module.obj_offset))
+            if module.core_layout:
+                outfd.write("{2:x} {0:s} {1:d}\n".format(module.name, module.core_layout.m('size'), module.core_layout.obj_offset))
+            else:
+                outfd.write("{2:x} {0:s} {1:d}\n".format(module.name, module.init_size + module.core_size, module.obj_offset))
 
             # will be empty list if not set on command line
             for sect in sections:


### PR DESCRIPTION
Kernels later than 3.9 use a struct core_layout as part of struct module to keep track of size and location of a kernel module.

As a result, the lsmod plugin and the volshell modules() command were broken.