### PR TITLE
Linux - Fix infinite recursion call in core_size and init_size

### DIFF
--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -842,10 +842,8 @@ class module_struct(obj.CType):
     def init_size(self):
         if hasattr(self, "init_layout"):
             ret = self.m("init_layout").m("size")
-        elif hasattr(self, "init_size"):
-            ret = self.m("init_size")
         else:
-            ret = 0
+            ret = self.m("init_size")
 
         return ret
  
@@ -853,10 +851,8 @@ class module_struct(obj.CType):
     def core_size(self):
         if hasattr(self, "core_layout"):
             ret = self.m("core_layout").m("size")
-        elif hasattr(self, "core_size"):
-            ret = self.m("core_size")
         else:
-            ret = 0
+            ret = self.m("core_size")
 
         return ret
         


### PR DESCRIPTION
We fixed the infinite calling recursion in core_size and init_size properties. This bug was introduced in commit 16af7d3d7db818d53fcbcc93e3620dcfbc063a09.