### PR TITLE
Support new OS X KDK DMG layout.

### DIFF
--- a/tools/mac/mac_create_all_profiles.py
+++ b/tools/mac/mac_create_all_profiles.py
@@ -182,8 +182,8 @@ def main():
 
     # Now look in the local Apple developer Library for installed KDKs. Pre 10.10
     # KDKs don't have the .pkg installer, so we start at 10.10.
-    kdk_root_dir = "/Library/Developer/KDKs"
-    for kit in os.listdir("/Library/Developer/KDKs/"):
+    kdk_root_dir = "/Library/Developer/KDKs/"
+    for kit in os.listdir(kdk_root_dir):
         try:
             full_path = os.path.join(
                 kdk_root_dir, kit, "System/Library/Kernels/")


### PR DESCRIPTION
  * kit_dir is now optional
  * always looks in /Library/Developer/KDKs for 10.10+ kits

The KDK file name schema on the Apple Developer Center has also changed a couple of times in recent releases and we can't rely on it for identification of things like build numbers. This change looks in /Library/Developers/KDKs to perform such identification for the new KDKs.