### PR TITLE
Fix ssizetype KeyError

### DIFF
--- a/volatility/dwarf.py
+++ b/volatility/dwarf.py
@@ -121,7 +121,7 @@ class DWARFParser(object):
 
     def base_type_name(self, data):
         """Replace references to base types."""
-        if 'DW_AT_name' in data:
+        if 'DW_AT_name' in data and data['DW_AT_name'] in self.tp2vol:
             return self.tp2vol[data['DW_AT_name'].strip('"')]
         else:
             sz = int(data['DW_AT_byte_size'], self.base)


### PR DESCRIPTION
Got this with Ubuntu 16.04 kernel `4.4.0-57` x64 (custom profile):
```
Volatility Foundation Volatility Framework 2.6
Traceback (most recent call last):
  File "vol.py", line 192, in <module>
    main()
  File "vol.py", line 183, in main
    command.execute()
  File "/root/volatility/volatility/commands.py", line 116, in execute
    if not self.is_valid_profile(profs[self._config.PROFILE]()):
  File "/root/volatility/volatility/plugins/overlays/linux/linux.py", line 216, in __init__
    obj.Profile.__init__(self, *args, **kwargs)
  File "/root/volatility/volatility/obj.py", line 862, in __init__
    self.reset()
  File "/root/volatility/volatility/plugins/overlays/linux/linux.py", line 227, in reset
    self.load_vtypes()
  File "/root/volatility/volatility/plugins/overlays/linux/linux.py", line 264, in load_vtypes
    vtypesvar = dwarf.DWARFParser(dwarfdata).finalize()
  File "/root/volatility/volatility/dwarf.py", line 71, in __init__
    self.feed_line(line)
  File "/root/volatility/volatility/dwarf.py", line 162, in feed_line
    self.process_statement(**parsed) #pylint: disable-msg=W0142
  File "/root/volatility/volatility/dwarf.py", line 225, in process_statement
    self.id_to_name[statement_id] = [self.base_type_name(data)]
  File "/root/volatility/volatility/dwarf.py", line 125, in base_type_name
    return self.tp2vol[data['DW_AT_name'].strip('"')]
KeyError: 'ssizetype'
```

Memory dump challenge:
https://quals.nuitduhack.com/challenges/quals-ndh2k17/bender-bending-rodriguez/

My profile worked fine with this fix.