### PR TITLE
Update Yarascan to Support Compiled Yara Rules

### DIFF
--- a/volatility/plugins/malware/malfind.py
+++ b/volatility/plugins/malware/malfind.py
@@ -195,7 +195,7 @@ class YaraScan(taskmods.DllList):
         config.add_option('YARA-RULES', short_option = 'Y', default = None,
                         help = 'Yara rules (as a string)')
         config.add_option('YARA-FILE', short_option = 'y', default = None,
-                        help = 'Yara rules (rules file)')
+                        help = 'Yara rules (rules file or compiled rule)')
         config.add_option('DUMP-DIR', short_option = 'D', default = None,
                         help = 'Directory in which to dump the files')
         config.add_option('SIZE', short_option = 's', default = 256,
@@ -232,7 +232,13 @@ class YaraScan(taskmods.DllList):
                             'n' : 'rule r1 {strings: $a = ' + s + ' condition: $a}'
                             })
             elif self._config.YARA_FILE and os.path.isfile(self._config.YARA_FILE):
-                rules = yara.compile(self._config.YARA_FILE)
+                yara_handle = open(self._config.YARA_FILE)
+                buf = yara_handle.read(4)
+                yara_handle.close()
+                if buf == "YARA":
+                    rules = rules = yara.load(self._config.YARA_FILE)
+                else:
+                    rules = yara.compile(self._config.YARA_FILE)
             else:
                 debug.error("You must specify a string (-Y) or a rules file (-y)")
         except yara.SyntaxError, why:

--- a/volatility/plugins/malware/malfind.py
+++ b/volatility/plugins/malware/malfind.py
@@ -236,7 +236,7 @@ class YaraScan(taskmods.DllList):
                 buf = yara_handle.read(4)
                 yara_handle.close()
                 if buf == "YARA":
-                    rules = rules = yara.load(self._config.YARA_FILE)
+                    rules = yara.load(self._config.YARA_FILE)
                 else:
                     rules = yara.compile(self._config.YARA_FILE)
             else:


### PR DESCRIPTION
Simple PR to add in the support for compiled yara rules into yarascan.  

The existing yarascan plugin will take the yara rule and attempt to compile it, tossing an error if the rule doesn't compile.  This adds a simple check to see if the user is providing a complied yara rule rather than assuming text.

This becomes useful when pre-compiling a collection of rules into a single rule file and running this against the memory dump.  This will run many times faster than creating a loop to iterate over the rules files in a yara directory.

If the user gives a single yara rule file (text format) the PR will attempt to compile it like usual.

A sample run would look like the following:

`yarac rule1.yar rule2.yar rule3.yar compiled_output.yar`

```
python volatility/vol.py -f memdump.bin --profile=Win2003SP2x86 yarascan -y compiled.yar
Volatility Foundation Volatility Framework 2.6
Rule: smss
Owner: Process smss.exe Pid 312
0x48582a24  53 4d 53 53 3a 20 53 75 62 73 79 73 74 65 6d 20   SMSS:.Subsystem.
0x48582a34  65 78 65 63 75 74 65 20 66 61 69 6c 65 64 20 28   execute.failed.(
0x48582a44  25 57 5a 29 0a 00 00 00 64 00 65 00 62 00 75 00   %WZ)....d.e.b.u.
0x48582a54  67 00 00 00 5c 00 53 00 79 00 73 00 74 00 65 00   g...\.S.y.s.t.e.
...snip...
```