### PR TITLE
Linux4 8 kaslr support, take2

### DIFF
--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -219,7 +219,7 @@ def LinuxProfileFactory(profpkg):
         def clear(self):
             """Clear out the system map, and everything else"""
             self.sys_map = {}
-            self.virutal_shift = 0
+            self.virtual_shift = 0
             self.physical_shift = 0
             obj.Profile.clear(self)
 
@@ -2265,9 +2265,9 @@ class VolatilityDTB(obj.VolatilityMagic):
 
         good_dtb = -1
             
-        init_task_addr = tbl["init_task"][0][0] + physical_shift_address
-        dtb_sym_addr   = tbl[sym][0][0] + physical_shift_address
-        files_sym_addr = tbl["init_files"][0][0] + physical_shift_address
+        init_task_addr = tbl["init_task"][0][0] + virtual_shift_address
+        dtb_sym_addr   = tbl[sym][0][0] + virtual_shift_address
+        files_sym_addr = tbl["init_files"][0][0] + virtual_shift_address
        
         comm_offset   = profile.get_obj_offset("task_struct", "comm")
         pid_offset    = profile.get_obj_offset("task_struct", "pid")
@@ -2276,7 +2276,7 @@ class VolatilityDTB(obj.VolatilityMagic):
         pas           = self.obj_vm
         
         if physical_shift_address != 0 and virtual_shift_address != 0:
-            good_dtb  = dtb_sym_addr - shifts[0]
+            good_dtb  = dtb_sym_addr - shifts[0] + physical_shift_address - virtual_shift_address
             self.obj_vm.profile.physical_shift = physical_shift_address 
             self.obj_vm.profile.virtual_shift  = virtual_shift_address
 

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -2306,10 +2306,10 @@ class VolatilityDTB(obj.VolatilityMagic):
                 if pas.read(swapper_address + pid_offset, 4) != "\x00\x00\x00\x00":
                     continue
 
-                mm_buf = pas.read(swapper_address + mm_offset, read_sz)
-                mm_addr = struct.unpack(fmt, mm_buf)[0]
-                if mm_addr == 0:
-                    continue
+                #mm_buf = pas.read(swapper_address + mm_offset, read_sz)
+                #mm_addr = struct.unpack(fmt, mm_buf)[0]
+                #if mm_addr == 0:
+                #    continue
 
                 tmp_shift_address = swapper_address - (init_task_addr - shifts[0])
                 if tmp_shift_address & 0xfff != 0x000:


### PR DESCRIPTION
This is an updated version of Linux > 4.8 KASLR detection and dismisses the `linux_kaslr_shift` plugin entirely.

@atcuno implemented KASLR detection and calculation in upstreams Linux overlay, however at various spots incorrect calculations were done regarding which shift (physical vs virtual) was used.

I tested the attached patches with kernel 4.9 amd64 memory dumps that had KASLR en- and disabled.

Moreover a small typo is fixed.

One upstream change since my PR volatilityfoundation/volatility#385 made the DTB finder skip the only valid DTB in the images I checked, therefore I commented those lines (the `active_mm` checks).

@atcuno found a nicer way to determine the virtual shift; instead of walking through the paging levels, looking up the path to a target physical page and then calculating the diff between observed and expected virtual address, he simply used the virtual address stored in the `files` member of `init_task`s `task_struct` that points to the randomized address of symbol `init_files`. By calculating the difference to the `init_files` value in System.map you can also determine the `virtual_shift`.

I'd like to note that even though KASLR detection possibly finds the correct values with this PR the `linux_kaslr_shift` plugin might still come in handy, since in contrast to the way it is handled now it will not stop DTB finding after the first possible hit but looks further to find additional DTBs, so in cases where the first found DTB is not correct it can still help out.
However I'd like to use the more elegant `init_files` approach for the plugin as well and will refactor this first before resubmitting.