### PR TITLE
reflect ktime_t type change 

### DIFF
--- a/volatility/plugins/linux/common.py
+++ b/volatility/plugins/linux/common.py
@@ -286,8 +286,11 @@ def get_time_vars(obj_vm):
         oreal = timekeeper.offs_real
         oboot = timekeeper.offs_boot
 
-        tv64 = (oreal.tv64 & 0xffffffff) - (oboot.tv64 & 0xffffffff)
-
+        if hasattr(oreal,"tv64"):
+            tv64 = (oreal.tv64 & 0xffffffff) - (oboot.tv64 & 0xffffffff)
+        else:
+            tv64 = (oreal & 0xffffffff) - (oboot & 0xffffffff)
+            
         if tv64:
             tv64 = (tv64 / 100000000) * -1
             timeo = vol_timespec(tv64, 0) 


### PR DESCRIPTION
Since this [commit](https://github.com/torvalds/linux/commit/2456e855354415bfaeb7badaa14e11b3e02c8466), `ktime_t` is not a union anymore, so the `tv64` field doesn't exist. 
Please merge to make Volatility work with > 4.10 kernels! 