### PR TITLE
Linux - fix issue when loading program_headers.

### DIFF
--- a/volatility/plugins/overlays/linux/elf.py
+++ b/volatility/plugins/overlays/linux/elf.py
@@ -314,9 +314,9 @@ class elf_hdr(elf):
         arr_start = self.obj_offset + self.e_phoff
 
         if self.e_phnum > 128:
-            phnum = self.e_phnum
-        else:
             phnum = 128
+        else:
+            phnum = self.e_phnum
 
         for i in range(phnum):
             # use the real size


### PR DESCRIPTION
Instead of capping the number of program headers to examine to 128,
Volatility made the number to check at least 128. The validity check
later on made this mostly work, but this fixes the underlying issue.