### PR TITLE
AFF4 support bug fix

### DIFF
--- a/contrib/plugins/aspaces/aff4.py
+++ b/contrib/plugins/aspaces/aff4.py
@@ -33,6 +33,7 @@ import pyaff4
 from pyaff4 import data_store
 from pyaff4 import lexicon
 from pyaff4.container import Container
+from pyaff4 import rdfvalue
 
 LOGGER = logging.getLogger("pyaff4")
 LOGGER.setLevel(logging.ERROR)
@@ -57,7 +58,8 @@ class AFF4AddressSpace(standard.FileAddressSpace):
 
         # Cant stack an AFF4 image on another AFF4 images
         self.as_assert(type(base) != AFF4AddressSpace, "Cant stack AFF4 addressspace on same")
-        self.fhandle = Container.open(self.name)
+        self.urn = rdfvalue.URN.FromFileName(self.name)
+        self.fhandle = Container.open(self.urn)
         self.fsize = self.fhandle.Size()
         self.fhandle.seek(0)
         dtb = self.fhandle.parent.getDTB()


### PR DESCRIPTION
This helps resolve issue #467

Strangely, the latest AFF4 code on GitHub includes a [print statement](https://github.com/google/aff4/blob/master/pyaff4/pyaff4/container.py#L96) which outputs AFF4 metadata (below) each time pyaff4 is used to open a container, and would in turn be displayed just prior to Volatility's output:

> KernBase: 18446735277683695616
NtBuildNumber: 7601
Registers:
  CR3: 1601536
Imager: WinPmem 2.1.post4
NtBuildNumberAddr: 18446735277685475856
...
>

I'm going to open a separate issue with the AFF4 development team to see if we can get it removed.