### PR TITLE
Fix for issue #482

### DIFF
--- a/volatility/plugins/malware/apihooks.py
+++ b/volatility/plugins/malware/apihooks.py
@@ -736,7 +736,7 @@ class ApiHooks(procdump.ProcDump):
         push_val = None
         # Save the general purpose registers
         regs = {}
-
+        
         for op in distorm3.Decompose(va, data, mode):
 
             # Quit the loop when we have three instructions or when 
@@ -838,10 +838,7 @@ class ApiHooks(procdump.ProcDump):
             n += 1
 
         # Check EIP after the function prologue 
-        if outside_module(d):
-            return True, data, d
-        else:
-            return False, data, d
+        return outside_module(d), data, d
 
     def gather_stuff(self, _addr_space, module):
         """Use the Volatility object classes to enumerate
@@ -986,12 +983,9 @@ class ApiHooks(procdump.ProcDump):
 
             (hooked, data, dest_addr) = ret
 
-            if not hooked:
-                continue
-
             if not addr_space.is_valid_address(dest_addr):
                 continue
-
+               
             function_owner = module_group.find_module(dest_addr)
             if function_owner != module:
                 # only do this for kernel hooks
@@ -1014,6 +1008,41 @@ class ApiHooks(procdump.ProcDump):
                 # Add the first redirection
                 hook.add_hop_chunk(dest_addr, addr_space.zread(dest_addr, 24))
                 yield hook
+                
+            # some malwares place their hook inside a code cave inside the module, use with -N to follow the jump   
+            elif self._config.NO_WHITELIST :
+                ret = self.check_inline(dest_addr, addr_space,
+                module.DllBase, module.DllBase + module.SizeOfImage, 
+                mode = decode_bits)
+
+                if ret == None:
+                    continue
+
+                (hooked, data, dest_addr2) = ret
+
+                if not hooked:
+                    continue
+
+                if not addr_space.is_valid_address(dest_addr2):
+                    continue
+                
+                function_owner = module_group.find_module(dest_addr2)
+                if function_owner != module:
+                    print "here is a hook that wasn't detected'"
+                    hook = Hook(hook_type = HOOKTYPE_INLINE,
+                            hook_mode = hook_mode,
+                            function_name = n or '',
+                            function_address = function_address,
+                            hook_address = dest_addr2,
+                            hook_module = function_owner,
+                            victim_module = module,
+                            decode_bits = decode_bits,
+                            )
+                    # Add the function prologue 
+                    hook.add_hop_chunk(function_address, data)
+                    # Add the first redirection
+                    hook.add_hop_chunk(dest_addr2, addr_space.zread(dest_addr2, 24))
+                    yield hook
 
     def calculate(self):
 


### PR DESCRIPTION
This is a Fix for issue #482. apihooks wasn't detecting inline hooks installed by Kaspersky Antivirus, because they seem to place their hook inside a code cave, which points to another jump and so on, to finally land inside klhkum.dll (AO  Kaspersky Lab).

An example of newly found hook:
```
here is a hook that wasn't detected'
************************************************************************
Hook mode: Usermode
Hook type: Inline/Trampoline
Process: 6120 (???R)
Victim module: ntdll.dll (0x7ff9e5b70000 - 0x7ff9e5d42000)
Function: ntdll.dll!NtCreateThread at 0x7ff9e5c16a50
Hook address: 0x4a0190
Hooking module: <unknown>

Disassembly(0):
0x7ff9e5c16a50 ff2500000000     JMP QWORD [RIP+0x0]
0x7ff9e5c16a56 90               NOP
0x7ff9e5c16a57 014a00           ADD [RDX+0x0], ECX
0x7ff9e5c16a5a 0000             ADD [RAX], AL
0x7ff9e5c16a5c 0000             ADD [RAX], AL
0x7ff9e5c16a5e 48895c2408       MOV [RSP+0x8], RBX
0x7ff9e5c16a63 4889742410       MOV [RSP+0x10], RSI

Disassembly(1):
0x4a0190 ff2500000000     JMP QWORD [RIP+0x0]
0x4a0196 4057             PUSH RDI
0x4a0198 0100             ADD [RAX], EAX
0x4a019a 0000             ADD [RAX], AL
0x4a019c 0000             ADD [RAX], AL
0x4a019e cc               INT 3
0x4a019f 4c8bd1           MOV R10, RCX
0x4a01a2 b84e000000       MOV EAX, 0x4e
0x4a01a7 ff               DB 0xff`
```