### PR TITLE
add VMI AddressSpace

### DIFF
--- a/volatility/plugins/addrspaces/vmi.py
+++ b/volatility/plugins/addrspaces/vmi.py
@@ -1,0 +1,100 @@
+# Volatility
+#
+# Copyright 2011 Sandia Corporation. Under the terms of Contract
+# DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
+# retains certain rights in this software.
+#
+# Authors:
+# bdpayne@acm.org (Bryan D. Payne)
+# mathieu.tarral@protonmail.com (Mathieu Tarral)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+#
+from urlparse import urlparse
+from distutils.util import strtobool
+import volatility.addrspace as addrspace
+
+libvmi = None
+try:
+    import libvmi
+    from libvmi import Libvmi, VMIMode, CR3
+except ImportError:
+    pass
+
+SCHEME = 'vmi'
+
+
+class VMIAddressSpace(addrspace.BaseAddressSpace):
+    """
+    This address space can be used in conjunction with LibVMI
+    and the Python bindings for LibVMI.  The end result is that
+    you can connect Volatility to view the memory of a running
+    virtual machine from any virtualization platform that
+    LibVMI supports.
+
+    For this AS to be instantiated, we need the VM name to
+    connect to.
+    """
+
+    order = 90
+
+    def __init__(self, base, config, layered=False, **kwargs):
+        self.as_assert(libvmi, "The LibVMI python bindings must be installed")
+        self.as_assert(base is None or layered, 'Must be first Address Space')
+
+        url = config.LOCATION
+        vmi_url = urlparse(url)
+        self.as_assert(vmi_url.scheme == SCHEME,
+                       "URL scheme must be {}://".format(SCHEME))
+        self.as_assert(vmi_url.path, "No domain name specified")
+        domain = vmi_url.path[1:]
+        # hypervisor specified ?
+        self.mode = None
+        hypervisor = vmi_url.netloc
+        if hypervisor:
+            self.mode = VMIMode[hypervisor.upper()]
+        addrspace.BaseAddressSpace.__init__(self, base, config, **kwargs)
+        # build Libvmi instance
+        self.vmi = Libvmi(domain, mode=self.mode, partial=True)
+        self.min_addr = 0
+        self.max_addr = self.vmi.get_memsize()
+        self.dtb = self.vmi.get_vcpu_reg(CR3, 0)
+
+    def close(self):
+        self.vmi.destroy()
+
+    def read(self, addr, length):
+        buffer, bytes_read = self.vmi.read_pa(addr, length)
+        if bytes_read != length:
+            raise RuntimeError('Error while reading physical memory at '
+                               '{}'.format(hex(addr)))
+        return buffer
+
+    def zread(self, addr, length):
+        return self.vmi.read_pa_padded(addr, length)
+
+    def write(self, addr, data):
+        bytes_written = self.vmi.write_pa(addr, data)
+        if bytes_written != len(data):
+            return False
+        return True
+
+    def is_valid_address(self, addr):
+        if addr is None:
+            return False
+        return self.min_addr < addr < self.max_addr
+
+    def get_available_addresses(self):
+        yield (self.min_addr, self.max_addr)


### PR DESCRIPTION
Hi !
This PR aims to bring the support of a new address space based on virtual machine introspection.

ping @asabellico since she looked at the issue I opened a few weeks ago.

It uses [libvmi](https://github.com/libvmi/libvmi) to access the physical memory of a guest via the hypervisor's API.

The supported hypervisors at the moment are Xen and KVM.

Note: I would need more information about the `read` and `zread` methods.
Can they fail ? Because I'm raising a `RunetimeError` from `read`, and having discussed with Michael Cohen on the Rekall integration, the `read` wasn't supposed to fail, but fill the buffer with zeroes instead.

Usage:
~~~
./vol.py -l vmi:///nitro_win7x64 --profile=Win7SP0x64 pslist
~~~
Libvmi will attempt to detect the hypervisor, but you can also specify it in the URL:
~~~
./vol.py -l vmi://kvm/nitro_win7x64 --profile=Win7SP0x64 pslist
./vol.py -l vmi://xen/nitro_win7x64 --profile=Win7SP0x64 pslist
~~~

Example run:
~~~
$ ./vol.py -l vmi://kvm/nitro_win7x64 --profile=Win7SP0x64 pslist
Volatility Foundation Volatility Framework 2.6
LibVMI Version 0.11.0
LibVMI Driver Mode 1
--completed driver init.
--got id from name (nitro_win7x64 --> 2)
**set image_type = nitro_win7x64
--libvirt version 1003001
--qmp: virsh -c qemu:///system qemu-monitor-command nitro_win7x64 '{"execute": "pmemaccess", "arguments": {"path": "/tmp/vmictdOHL"}}'
--kvm: using custom patch for fast memory access
**set allocated_ram_size = 59700000, max_physical_address = 0x59700000
--qmp: virsh -c qemu:///system qemu-monitor-command nitro_win7x64 '{"execute": "human-monitor-command", "arguments": {"command-line": "info registers"}}'
Offset(V)          Name                    PID   PPID   Thds     Hnds   Sess  Wow64 Start                          Exit                          
------------------ -------------------- ------ ------ ------ -------- ------ ------ ------------------------------ ------------------------------
0xfffffa8001108890 System                    4      0     76      452 ------      0 2018-03-19 20:10:34 UTC+0000                                 
0xfffffa8002329950 smss.exe                248      4      2       29 ------      0 2018-03-19 20:10:34 UTC+0000                                 
0xfffffa8002963060 csrss.exe               316    308      8      285      0      0 2018-03-19 20:10:36 UTC+0000                                 
0xfffffa8002a4b7c0 wininit.exe             364    308      3       74      0      0 2018-03-19 20:10:36 UTC+0000                                 
0xfffffa80011837c0 csrss.exe               376    356      7      134      1      0 2018-03-19 20:10:36 UTC+0000                                 
0xfffffa8002ba0280 winlogon.exe            416    356      3      108      1      0 2018-03-19 20:10:36 UTC+0000                                 
0xfffffa8002bcc320 services.exe            460    364      5      178      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002bde450 lsass.exe               468    364      6      508      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002bd9830 lsm.exe                 476    364      9      135      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002be3b30 svchost.exe             580    460      9      334      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002984780 svchost.exe             652    460      5      201      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002c78700 svchost.exe             696    460     18      428      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002cc89e0 svchost.exe             804    460     15      400      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002ceab30 svchost.exe             844    460     23      830      0      0 2018-03-19 20:10:37 UTC+0000                                 
0xfffffa8002d40290 svchost.exe             996    460     12      301      0      0 2018-03-19 20:10:38 UTC+0000                                 
0xfffffa8002d78b30 svchost.exe             524    460     15      397      0      0 2018-03-19 20:10:38 UTC+0000                                 
0xfffffa8002dcc200 dwm.exe                1076    804      3       68      1      0 2018-03-19 20:10:38 UTC+0000                                 
0xfffffa8002dd95a0 explorer.exe           1088   1068     19      675      1      0 2018-03-19 20:10:38 UTC+0000                                 
0xfffffa8002e0d420 spoolsv.exe            1164    460     12      260      0      0 2018-03-19 20:10:39 UTC+0000                                 
0xfffffa8002e278e0 taskhost.exe           1196    460      7      142      1      0 2018-03-19 20:10:39 UTC+0000                                 
0xfffffa8002e33b30 svchost.exe            1220    460     19      305      0      0 2018-03-19 20:10:39 UTC+0000                                 
0xfffffa8002eb9060 svchost.exe            1380    460      8      154      0      0 2018-03-19 20:10:39 UTC+0000                                 
0xfffffa8002effb30 sppsvc.exe             1476    460      4      146      0      0 2018-03-19 20:10:39 UTC+0000                                 
0xfffffa8002fe7b30 wlms.exe               1752    460      4       41      0      0 2018-03-19 20:10:41 UTC+0000                                 
0xfffffa8002ffe170 svchost.exe            1828    460      5       89      0      0 2018-03-19 20:10:41 UTC+0000                                 
0xfffffa8002ec73f0 svchost.exe             292    460     13      336      0      0 2018-03-19 20:12:41 UTC+0000  
~~~

Please give some feedback !

Thanks.