### PR TITLE
Fix iehistory plugin to not override scan selection

### DIFF
--- a/volatility/plugins/iehistory.py
+++ b/volatility/plugins/iehistory.py
@@ -156,8 +156,6 @@ class IEHistory(taskmods.DllList):
             tags.append("LEAK")
         if self._config.REDR:
             tags.append("REDR")
-            
-        tags = ["DEST"]
 
         ## Define the record type based on the tag
         tag_records = {


### PR DESCRIPTION
All the tags are erroneously overwritten by only DEST. This results
in the plugin missing most of the data it should gather.