### PR TITLE
psxview: lsass.exe as okay if not in indesktop

### DIFF
--- a/volatility/plugins/malware/psxview.py
+++ b/volatility/plugins/malware/psxview.py
@@ -319,7 +319,7 @@ class PsXview(common.AbstractWindowsCommand, sessions.SessionsMixin):
                     elif process.ExitTime > 0:
                         insession = "Okay"
                 if not indesktop:
-                    if str(process.ImageFileName).lower() in ["system", "smss.exe"]:
+                    if str(process.ImageFileName).lower() in ["system", "smss.exe", "lsass.exe"]:
                         indesktop = "Okay"
                     elif process.ExitTime > 0:
                         indesktop = "Okay"
@@ -395,7 +395,7 @@ class PsXview(common.AbstractWindowsCommand, sessions.SessionsMixin):
                     elif process.ExitTime > 0:
                         insession = "Okay"
                 if not indesktop:
-                    if str(process.ImageFileName).lower() in ["system", "smss.exe"]:
+                    if str(process.ImageFileName).lower() in ["system", "smss.exe", "lsass.exe"]:
                         indesktop = "Okay"
                     elif process.ExitTime > 0:
                         indesktop = "Okay"
@@ -459,7 +459,7 @@ class PsXview(common.AbstractWindowsCommand, sessions.SessionsMixin):
                     elif process.ExitTime > 0:
                         insession = "Okay"
                 if not indesktop:
-                    if str(process.ImageFileName).lower() in ["system", "smss.exe"]:
+                    if str(process.ImageFileName).lower() in ["system", "smss.exe", "lsass.exe"]:
                         indesktop = "Okay"
                     elif process.ExitTime > 0:
                         indesktop = "Okay"


### PR DESCRIPTION
For #520, although it looks like the whole -R option should be updated as the code is repeated a few times for different rendering options. 