### PR TITLE
prevent infinite looping handling fops

### DIFF
--- a/volatility/plugins/linux/check_fops.py
+++ b/volatility/plugins/linux/check_fops.py
@@ -121,6 +121,8 @@ class linux_check_fop(linux_common.AbstractLinuxCommand):
                 if cur.obj_offset == last_cur:
                     break
 
+                if cur == cur.next:
+                    break
                 cur = cur.next
                 continue
 
@@ -139,6 +141,8 @@ class linux_check_fop(linux_common.AbstractLinuxCommand):
                 subdir = subdir.next
 
             last_cur = cur.obj_offset
+            if cur == cur.next:
+                break
             cur = cur.next
 
     def _walk_rb(self, rb):

--- a/volatility/plugins/linux/check_inline_kernel.py
+++ b/volatility/plugins/linux/check_inline_kernel.py
@@ -170,6 +170,8 @@ class linux_check_inline_kernel(linux_common.AbstractLinuxCommand):
     def walk_proc(self, cur, f_op_members, modules, parent = ""):
         while cur:
             if cur.obj_offset in self.seen_proc:
+                if cur == cur.next:
+                    break
                 cur = cur.next
                 continue
 
@@ -192,6 +194,8 @@ class linux_check_inline_kernel(linux_common.AbstractLinuxCommand):
                     yield (sub_name, hooked_member, hook_type, hook_address)
                 subdir = subdir.next
 
+            if cur == cur.next:
+                break
             cur = cur.next
 
     def check_proc_root_fops(self, f_op_members, modules):   


### PR DESCRIPTION
On a handful of images I have, iterating over the linked list as is would loop forever.

This addresses the instances I was experiencing.