### PR TITLE
Fix updated pyinstaller "empty DEST" issue

### DIFF
--- a/pyinstaller/hook-distorm3.py
+++ b/pyinstaller/hook-distorm3.py
@@ -16,7 +16,7 @@ datas = []
 
 for path in sys.path:
     if os.path.exists(os.path.join(path, "distorm3", "distorm3.dll")):
-        datas.append((os.path.join(path, "distorm3", "distorm3.dll"), ""))
+        datas.append((os.path.join(path, "distorm3", "distorm3.dll"), "."))
     if os.path.exists(os.path.join(path, "distorm3", "libdistorm3.so")):
-        datas.append((os.path.join(path, "distorm3", "libdistorm3.so"), ""))
+        datas.append((os.path.join(path, "distorm3", "libdistorm3.so"), "."))
 

--- a/pyinstaller/hook-openpyxl.py
+++ b/pyinstaller/hook-openpyxl.py
@@ -16,4 +16,4 @@ datas = []
 
 for path in sys.path:
     if os.path.exists(os.path.join(path, "openpyxl", ".constants.json")):
-        datas.append((os.path.join(path, "openpyxl", ".constants.json"), ""))
+        datas.append((os.path.join(path, "openpyxl", ".constants.json"), "."))

--- a/pyinstaller/hook-yara.py
+++ b/pyinstaller/hook-yara.py
@@ -5,6 +5,6 @@ datas = []
 
 for path in sys.path:
     if os.path.exists(os.path.join(path, "yara.pyd")):
-        datas.append((os.path.join(path, "yara.pyd"), ""))
+        datas.append((os.path.join(path, "yara.pyd"), "."))
     if os.path.exists(os.path.join(path, "yara.so")):
-        datas.append((os.path.join(path, "yara.so"), ""))
+        datas.append((os.path.join(path, "yara.so"), "."))


### PR DESCRIPTION
Current version of pyinstaller cannot accept an empty DESTINATION, assuming current directory.
https://github.com/pyinstaller/pyinstaller/issues/3066
This affects "hook-yara.py", "hook-distorm3.py" and "hook-openpyxl.py"