### PR TITLE
Fixed bug on shellbags command when the output is json

### DIFF
--- a/volatility/renderers/html.py
+++ b/volatility/renderers/html.py
@@ -48,4 +48,4 @@ class JSONRenderer(Renderer):
             raise NotImplementedError("JSON output for trees has not yet been implemented")
         # TODO: Output (basic) type information in JSON
         json_input = {"columns": [column.name for column in data.columns], "rows": data.visit(None, self.render_row, [])}
-        return outfd.write(json.dumps(json_input))
+        return outfd.write(json.dumps(json_input,ensure_ascii=False))


### PR DESCRIPTION
Update html.py for bug on shellbags command when the output is set to json

Command: vol.py -f memory_dump --profile=Win7SP1x64_24000 shellbags --output=json
Error: UnicodeDecodeError: 'utf8' codec can't decode byte 0xb5 in position 0: invalid start byte