### PR TITLE
Bump to 2.6.1

### DIFF
--- a/volatility/constants.py
+++ b/volatility/constants.py
@@ -23,7 +23,7 @@
 
 import os, sys
 
-VERSION = "2.6"
+VERSION = "2.6.1"
 
 SCAN_BLOCKSIZE = 1024 * 1024 * 10
 


### PR DESCRIPTION
Trying to package for OpenSUSE the update 2.6.1 I discovered that the constant version is still in 2.6. Maybe it would be better to modify it to 2.6.1.