### PR TITLE
Netfilter plugin improvements

### DIFF
--- a/volatility/plugins/linux/netfilter.py
+++ b/volatility/plugins/linux/netfilter.py
@@ -57,7 +57,7 @@ class linux_netfilter(linux_common.AbstractLinuxCommand):
                 list_head = obj.Object("list_head", offset = arr + (hook_idx * list_head_size), vm = self.addr_space)
         
                 for hook_ops in list_head.list_of_type("nf_hook_ops", "list"):
-                    found, module = self.is_known_address_name(hook_ops.hook.v(), modules) or ""
+                    found, module = self.is_known_address_name(hook_ops.hook.v(), modules) 
                     hooked = "False" if found else "True"
 
                     yield proto_name, hook_name, hook_ops.hook.v(), hooked, module

--- a/volatility/plugins/linux/netfilter.py
+++ b/volatility/plugins/linux/netfilter.py
@@ -39,20 +39,19 @@ class linux_netfilter(linux_common.AbstractLinuxCommand):
         linux_common.set_plugin_members(self)
 
         hook_names = ["PRE_ROUTING", "LOCAL_IN", "FORWARD", "LOCAL_OUT", "POST_ROUTING"]
-
         proto_names = ["UNSPEC", "INET", "IPV4", "ARP", "", "NETDEV", "", "BRIDGE", "", "", "IPV6" , "", "DECNET"]
+        NF_MAX_HOOKS = 8
 
         nf_hooks_addr = self.addr_space.profile.get_symbol("nf_hooks")
-
         if nf_hooks_addr == None:
             debug.error("Unable to analyze NetFilter. It is either disabled or compiled as a module.")
 
-        modules  = linux_lsmod.linux_lsmod(self._config).get_modules()
+        modules = linux_lsmod.linux_lsmod(self._config).get_modules()
          
         list_head_size = self.addr_space.profile.get_obj_size("list_head")
         
         for proto_idx, proto_name in enumerate(proto_names):
-            arr = nf_hooks_addr + (proto_idx * (list_head_size * 8))
+            arr = nf_hooks_addr + (proto_idx * (list_head_size * NF_MAX_HOOKS))
            
             for hook_idx, hook_name in enumerate(hook_names):
                 list_head = obj.Object("list_head", offset = arr + (hook_idx * list_head_size), vm = self.addr_space)


### PR DESCRIPTION
 * Added LKM lookup, showing the kernel module name to which the hook belongs to.
 * If the module is part of the kernel text, it also resolves the symbol to that specific address. It is showed between square brackets, ie: [selinux_ipv4_forward]
 * All kernel existing protocols were added (unless until kernel v4.20). It now allows to identify for instance IPv6, ARP, BRIDGE (ebtables), etc.
 * Removed hardcoded sizes.
 * Added function to the Linux common API to find LKM module addresses, similar to the one in mac implementation but it also resolve kernel symbols.

See and compare the output:
[Old netfilter plugin output](https://github.com/volatilityfoundation/volatility/files/2722773/old_netfilter_plugin_output.txt)
[New netfilter plugin output](https://github.com/volatilityfoundation/volatility/files/2722774/new_netfilter_plugin_output.txt)
