### PR TITLE
Handling kuid_t/kgid_t types in struct inode

### DIFF
--- a/volatility/plugins/linux/dentry_cache.py
+++ b/volatility/plugins/linux/dentry_cache.py
@@ -47,7 +47,7 @@ class linux_dentry_cache(linux_common.AbstractLinuxCommand):
         i = dentry.d_inode
         
         if i:
-            ret = [0, path, i.i_ino, 0, i.i_uid, i.i_gid, i.i_size, i.i_atime, i.i_mtime, 0, i.i_ctime]
+            ret = [0, path, i.i_ino, 0, i.uid, i.gid, i.i_size, i.i_atime, i.i_mtime, 0, i.i_ctime]
         else:
             ret = [0, path] + [0] * 8
             

--- a/volatility/plugins/linux/recover_filesystem.py
+++ b/volatility/plugins/linux/recover_filesystem.py
@@ -47,7 +47,7 @@ class linux_recover_filesystem(linux_common.AbstractLinuxCommand):
             out_path = os.path.join(self._config.DUMP_DIR, *ents)
 
             os.chmod(out_path, inode.i_mode & 00777)
-            os.chown(out_path, inode.i_uid, inode.i_gid)
+            os.chown(out_path, inode.uid, inode.gid)
             os.utime(out_path, (inode.i_atime.tv_sec, inode.i_mtime.tv_sec))
 
     def _write_file(self, ff, file_path, file_dentry):

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -2244,7 +2244,25 @@ class super_block(obj.CType):
         return self.s_dev & ((1 << 20) - 1)
 
 class inode(obj.CType):
+    @property
+    def uid(self):
+        
+        try:
+            ret = int(self.i_uid)
+        except TypeError:
+            ret = int(self.i_uid.val)
 
+        return ret
+
+    @property
+    def gid(self):
+        
+        try:
+            ret = int(self.i_gid)
+        except TypeError:
+            ret = int(self.i_gid.val)
+        return ret
+    
     def is_dir(self):
         """Mimic the S_ISDIR macro"""
         return self.i_mode & linux_flags.S_IFMT == linux_flags.S_IFDIR


### PR DESCRIPTION
In the "latest" kernels the fields `i_uid` and `i_gid` of `struct inode` are respectively of type `kuid_t` and `kgid_t`. To retrieve their value we need to access the `val` field of these types.
This PR should resolve  #462 and #509 while maintaining backwards compatibility.


