### PR TITLE
Avoiding an infinite loop if the vma rb-tree is smeared.

### DIFF
--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -1951,6 +1951,9 @@ class task_struct(obj.CType):
         rb = self.mm.mm_rb.rb_node
 
         for vma in self._walk_rb(rb):
+            if vma.vm_start in vmas:
+                debug.warning("Detected corruption in the memory mappings red-black tree")
+                break
             vmas[vma.vm_start] = vma
  
         for key in sorted(vmas.iterkeys()):


### PR DESCRIPTION
This commit prevents an infinite loop in case the rb-tree containing the memory mappings of a process is smeared. 

The bug can be triggered with the following test case:
profile: http://www.s3.eurecom.fr/~pagabuc/rbtree_loop/profile.zip
memory dump: http://www.s3.eurecom.fr/~pagabuc/rbtree_loop/ram.lime.tar.gz
Volatility command: `linux_proc_maps_rb -p 3020`