### PR TITLE
Fixed broken BaseYaraScanner

### DIFF
--- a/volatility/plugins/malware/malfind.py
+++ b/volatility/plugins/malware/malfind.py
@@ -107,13 +107,13 @@ class BaseYaraScanner(object):
             data = self.address_space.zread(i, to_read)
             if data:
                 for rule in rules:
-                    for match in rule.match(data = data):
-                        # We currently don't use name or value from the 
-                        # yara results but they can be yielded in the 
-                        # future if necessary. 
-                        for moffset, _name, _value in match.strings:
-                            if moffset < constants.SCAN_BLOCKSIZE:
-                                yield match, moffset + i
+                    matches = rule.match(data=data)
+                    if matches:
+                        for k, v in matches.iteritems():
+                            for yara_strings in v[0].get("strings"):
+                                moffset = yara_strings.get("offset")
+                                if moffset < constants.SCAN_BLOCKSIZE:
+                                    yield matches, moffset + i
 
             i += constants.SCAN_BLOCKSIZE
 


### PR DESCRIPTION
Yara-python is returning dict, so the current code will never work.
We need to iterate further, to get to match offset.