### PR TITLE
Minor fix to malfind

### DIFF
--- a/volatility/plugins/malware/malfind.py
+++ b/volatility/plugins/malware/malfind.py
@@ -426,6 +426,8 @@ class Malfind(vadinfo.VADDump):
         if self._config.DUMP_DIR and not os.path.isdir(self._config.DUMP_DIR):
             debug.error(self._config.DUMP_DIR + " is not a directory")
 
+        refined_criteria = ["MZ", "\x55\x8B"]
+
         for task in data:
             for vad, address_space in task.get_vads(vad_filter = task._injection_filter):
 
@@ -433,6 +435,9 @@ class Malfind(vadinfo.VADDump):
                     continue
 
                 content = address_space.zread(vad.Start, 64) 
+
+                if self._config.REFINED and content[0:2] not in refined_criteria:
+                    continue
 
                 yield (0, [str(task.ImageFileName), 
                            int(task.UniqueProcessId),


### PR DESCRIPTION
Specifying -W does not currently get applied to unified output, just text output. Update will report refined results for unified output if -W is supplied.