### PR TITLE
Arm64

### DIFF
--- a/volatility/dwarf.py
+++ b/volatility/dwarf.py
@@ -50,6 +50,7 @@ class DWARFParser(object):
         'unsigned int': 'unsigned int',
         'sizetype' : 'unsigned long',
         'ssizetype' : 'long',
+        '__int128 unsigned': 'unsigned long long',
     }
 
 

--- a/volatility/plugins/addrspaces/arm64.py
+++ b/volatility/plugins/addrspaces/arm64.py
@@ -1,0 +1,92 @@
+# Volatility
+#
+# This file is part of Volatility.
+#
+# Volatility is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Volatility is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Volatility.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import struct
+import volatility.obj as obj
+import volatility.debug as debug #pylint: disable-msg=W0611
+import volatility.plugins.addrspaces.paged as paged
+
+
+class Arm64AddressSpace(paged.AbstractWritablePagedMemory):
+    """Address space for ARM64 processors"""
+
+    order = 800
+    pae = False
+    paging_address_space = True
+    checkname = 'Arm64ValidAS'
+    minimum_size = 0x1000
+    alignment_gcd = 0x1000
+    _longlong_struct = struct.Struct('<Q')
+
+    def read_longlong_phys(self, addr):
+        '''
+        Returns an unsigned 64-bit integer from the address addr in
+        physical memory. If unable to read from that location, returns None.
+        '''
+        try:
+            string = self.base.read(addr, 8)
+        except IOError:
+            string = None
+        if not string:
+            return obj.NoneObject("Could not read_longlong_phys at offset " + hex(addr))
+        longlongval, = self._longlong_struct.unpack(string)
+        return longlongval
+
+    def ptbl_lowbits(self, level):
+        return 12 + 9 * (3 - level)
+
+    def ptbl_index(self, vaddr, level):
+        return (vaddr >> self.ptbl_lowbits(level)) & 0x1ff
+
+    def ptbl_walk(self, vaddr, base):
+        if (vaddr == 0):
+            return None
+        for level in xrange(4):
+            index = self.ptbl_index(vaddr, level)
+            entry = self.read_longlong_phys(base + (index << 3))
+            if not entry:
+                return None
+            # clear high bits
+            entry_addressbits = entry & ((1 << 47) - 1)
+            # clear low bits
+            entry_addressbits = entry_addressbits & (~0xfff)
+            # entry not valid
+            if not (entry & 0x1):
+                return None
+            if (level == 3 and (entry & 0x3 != 0x3)):
+                return None
+            # entry points to final address
+            if (level == 3 or (entry & 0x3 == 0x1)):
+                lowbitmask = (1 << self.ptbl_lowbits(level)) - 1
+                return entry_addressbits & (~lowbitmask) | (vaddr & lowbitmask)
+            # entry points to next table
+            base = entry_addressbits
+        return None
+
+    def vtop(self, vaddr):
+        debug.debug("\n--vtop start: {0:x}".format(vaddr), 4)
+
+        return self.ptbl_walk(vaddr, self.dtb)
+
+    # FIXME
+    # this is supposed to return all valid physical addresses based on the current dtb
+    # this (may?) be painful to write due to ARM's different page table types and having small & large pages inside of those
+    def get_available_pages(self):
+
+        for i in xrange(0, (2 ** 32) - 1, 4096):
+            yield (i, 0x1000)

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -120,6 +120,7 @@ linux_overlay = {
         'ArmValidAS'   :  [ 0x0, ['VolatilityLinuxARMValidAS']],
         'IA32ValidAS'  :  [ 0x0, ['VolatilityLinuxIntelValidAS']],
         'AMD64ValidAS'  :  [ 0x0, ['VolatilityLinuxIntelValidAS']],
+        'Arm64ValidAS'   :  [ 0x0, ['VolatilityLinuxARM64ValidAS']],
         }],
     'vm_area_struct' : [ None, { 
         'vm_flags' : [ None, ['LinuxPermissionFlags', {'bitmap': {'r': 0, 'w': 1, 'x': 2}}]],
@@ -2493,6 +2494,24 @@ class VolatilityLinuxARMValidAS(obj.VolatilityMagic):
 
             yield fork_off - task_off == sym_addr_diff
 
+class VolatilityLinuxARM64ValidAS(obj.VolatilityMagic):
+    """An object to check that an address space is a valid Arm64 Paged space"""
+    def generate_suggestions(self):
+
+        init_task_addr = self.obj_vm.profile.get_symbol("init_task")
+        do_fork_addr   = self.obj_vm.profile.get_symbol("_do_fork")
+
+        if not do_fork_addr or not init_task_addr:
+            return
+
+        task_paddr = self.obj_vm.vtop(init_task_addr)
+        do_fork_paddr = self.obj_vm.vtop(do_fork_addr)
+
+        if not do_fork_paddr or not task_paddr:
+            return
+
+        yield do_fork_paddr - task_paddr == do_fork_addr - init_task_addr
+
 class LinuxObjectClasses(obj.ProfileModification):
     conditions = {'os': lambda x: x == 'linux'}
     before = ['BasicObjectClasses']
@@ -2518,6 +2537,7 @@ class LinuxObjectClasses(obj.ProfileModification):
             'Ipv6Address': basic.Ipv6Address,
             'VolatilityLinuxIntelValidAS' : VolatilityLinuxIntelValidAS,
             'VolatilityLinuxARMValidAS' : VolatilityLinuxARMValidAS,
+            'VolatilityLinuxARM64ValidAS' : VolatilityLinuxARM64ValidAS,
             'kernel_param' : kernel_param,
             'kparam_array' : kparam_array,
             'desc_struct' : desc_struct,

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -156,6 +156,9 @@ def parse_system_map(data, module):
         if symbol == "arm_syscall":
             arch = "ARM"
 
+        if symbol == "arm64_dma_phys_limit":
+            arch = "arm64"
+
         if not symbol in sys_map[module]:
             sys_map[module][symbol] = []
 
@@ -191,9 +194,6 @@ def LinuxProfileFactory(profpkg):
         elif 'system.map' in f.filename.lower():
             sysmapdata = profpkg.read(f.filename)
             arch, memmodel, sysmap = parse_system_map(profpkg.read(f.filename), "kernel")
-
-    if memmodel == "64bit":
-        arch = "x64"
 
     if not sysmapdata or not dwarfdata:
         # Might be worth throwing an exception here?

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -2331,7 +2331,12 @@ class VolatilityDTB(obj.VolatilityMagic):
         config = self.obj_vm.get_config()
         tbl    = self.obj_vm.profile.sys_map["kernel"]
         
-        if profile.metadata.get('memory_model', '32bit') == "32bit":
+        if profile.metadata.get('arch') == 'arm64':
+            sym = "swapper_pg_dir"
+            shifts  = [0xffff000000000000, 0xffff800000000000]
+            read_sz = 8
+            fmt     = "<Q"
+        elif profile.metadata.get('memory_model', '32bit') == "32bit":
             sym     = "swapper_pg_dir"
             shifts  = [0xc0000000]
             read_sz = 4
@@ -2416,8 +2421,9 @@ class VolatilityDTB(obj.VolatilityMagic):
 
                 good_dtb = (dtb_sym_addr - shifts[0] + 0) + tmp_physical_shift 
 
-                if pas.zread(good_dtb, 8) != "\x00\x00\x00\x00\x00\x00\x00\x00":
-                    continue
+                if profile.metadata.get('arch') != 'arm64':
+                    if pas.zread(good_dtb, 8) != "\x00\x00\x00\x00\x00\x00\x00\x00":
+                        continue
 
                 if sched_class_offset != -1:
                     sched_class_val = pas.read(swapper_address + sched_class_offset, read_sz)

--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -2516,7 +2516,12 @@ class VolatilityLinuxARM64ValidAS(obj.VolatilityMagic):
         if not do_fork_paddr or not task_paddr:
             return
 
-        yield do_fork_paddr - task_paddr == do_fork_addr - init_task_addr
+        res = (do_fork_paddr - task_paddr == do_fork_addr - init_task_addr)
+
+        if res:
+            self.obj_vm.set_curr_base_valid()
+
+        yield res
 
 class LinuxObjectClasses(obj.ProfileModification):
     conditions = {'os': lambda x: x == 'linux'}


### PR DESCRIPTION
Hello!

This merge request is addressing https://github.com/volatilityfoundation/volatility/issues/687 - adding arm64 linux support for volatility.
I would be very happy to hear your comments on code and fix as needed.
Most work is rather straight forward - adapting for arm64 page-table format and kernel symbols.
Two important notes:

1. supporting dual-pagetables was not entirely straight forward. In arm64 the entire kernel space is translated with a single pagetable for all process, and each userspace has it's own pagetable only translating userspace addresses (separated by the msb). Thus when working on a process two DTBs must be used. In my implementation (in a separate patch): when the arm64 validity checker finds a valid addresspace, it notifies the addresspace that it is valid - and then that DTB will be stored in the addresspace class as the kernel's page-table. The fisrt valid DTB will then be used as kernelspace DTB, while userspace dtbs may come from the address-space constructor.
2. I currently kept the temporary arm32 get_available_pages implementation. I do intend to fix it with a more complete page-table parsing implementation.