### PR TITLE
Fix getkcore.c when KASLR is enabled

### DIFF
--- a/tools/linux/kcore/getkcore.c
+++ b/tools/linux/kcore/getkcore.c
@@ -19,8 +19,6 @@ This file exposes all of physical memory (including hardware devices) as ELF sec
 
 To acquire memory, the script first parses /proc/iomem and determines ranges of "System RAM".
 It then parses the sections of /proc/kcore and matches "System RAM" regions to those found in the kcore file.
-This matching is possible by using the static offset (0xffff880000000000) of the virtual mapping of RAM.
-See the _find_kcore_sections function for this algorithm
 
 Each RAM region found is then written to a LiME formatted file so that it can be immediately analyzed with Volatility.
 
@@ -146,7 +144,7 @@ void _process_header(int kcore_fd, int out_fd, unsigned long long phdr_addr, uns
     if (read(kcore_fd, &p, sizeof(p)) != sizeof(p))
         _die("_process_header: Unable to read program header: %x | %x\n", phdr_addr, phys_start);
 
-    if (phys_start + 0xffff880000000000 == p.p_vaddr)
+    if (phys_start == p.p_paddr)
     {
         _write_lime_header(out_fd, phys_start, p.p_memsz);
         _read_write_region(kcore_fd, out_fd, &p, phys_start, read_buf);


### PR DESCRIPTION
The getkcore.c PoC didn't work with KASLR enabled, this commit fixes the bug.  It finds the RAM regions in kcore by using program header's physical addresses instead of using the hard-coded base address 0xffff880000000000.

Without KASLR (kernel booted with the *nokaslr* option):

```
# readelf -aW /proc/kcore
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
[...]
  LOAD           0x88000003000 0xffff888000001000 0x0000000000001000 0x09e000 0x09e000 RWE 0x1000
  LOAD           0x88000102000 0xffff888000100000 0x0000000000100000 0x3fef0000 0x3fef0000 RWE 0x1000
```

With KASLR, *virtAddr* are randomized, the hard-coded value can't be used:

```
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  LOAD           0x168e00003000 0xffff968e00001000 0x0000000000001000 0x09e000 0x09e000 RWE 0x1000
  LOAD           0x168e00102000 0xffff968e00100000 0x0000000000100000 0x3fef0000 0x3fef0000 RWE 0x1000
```