### PR TITLE
Plugins for SLOB/SLUB analysis

### DIFF
--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -239,13 +239,53 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                     num_objs = 0
                     # size = obj.Object('int', vm = cache.obj_vm, name = "size")
                     objperslabs = 0
-                    node_off = self.profile.get_obj_offset("kmem_cache", "node")
+                    pagesperslab = 0
+                    node = cache.m('node')
+                    #print node.d()
+                    cache_node = obj.Object('kmem_cache_node', offset = node[0], vm = self.addr_space)
+                    #print cache_node.nr_partial
+                    #print hex(cache_node.partial.next)
+                    page = obj.Object('page', offset = cache_node.partial.next, vm = self.addr_space)
+                    #print page.objects - page.inuse
+                    #for i in node:
+                    #    cache_node = obj.Object('kmem_cache_node', offset = i, vm = self.addr_space)
+                    #    if cache_node.is_valid():
+                    #        page = obj.Object('page', offset = cache_node.partial.next, vm = self.addr_space)
+                    #        print page.freelist
+                    #print hex(page.freelist)
+                    #while page.next > 0x1000000000000000:
+                    #    print page.freelist
+                        #print page.members
+                    #    page = obj.Object('page', offset = page.next, vm = self.addr_space)
+                    #print list(self.addr_space.read(0xffff88007d008e00L, 192))
+                    #print page.freelist
+                    #print page.inuse
+                    #print page.objects
+                    #print page.counters
+                    #if page.index == 0:
+                    #    print 0
+                    #else: 
+                    #    print page.counters / page.index
+                    #print page.pages
+                    #print page.pobjects
+                    #page2 = obj.Object('page', offset = page.next, vm = self.addr_space)
+                    #print page2.counters
+                    #print page2.inuse
+                    #print page2.freelist
+                    #print list(self.addr_space.read(0xffff88007d002900, 10))
+                    #print hex(page.freelist)
+                    #print cache.m('node').d()
+                    #for i in cache.members:
+                    #    print i
+                    #print cache.members['node'][0]
+                    #print cache.m("name")
+                    #node_off = self.profile.get_obj_offset("kmem_cache", "node")
                     # print("nodeoff "+str(node_off))
                     # for slab in cache._get_partial_list(node_off):
                     #     active_objs += slab.objects
                     #     active_slabs += 1
 
-                    cache._get_partial_list(node_off)
+                    #cache._get_partial_list(node_off)
 
                     # for slab in cache._get_free_list():
                     #     num_slabs += 1
@@ -254,8 +294,8 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                             active_objs,
                             num_objs,
                             cache.m("size"),
-                            "ciao",
                             objperslabs,
+                            pagesperslab,
                             active_slabs,
                             num_slabs]
 

--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -288,35 +288,6 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                     medium_pages = [slob for slob in slob_medium.list_of_type("page", "slab_list")]
                     large_pages = [slob for slob in slob_large.list_of_type("page", "slab_list")]
 
-                    #if(dump_list == 's'):
-                    #    page_list = small_pages
-                    #elif(dump_list == 'm'):
-                    #    page_list = medium_pages
-                    #elif(dump_list == 'l'):
-                    #    page_list = large_pages
-                    #if(page_list != None):
-                    #    for page in page_list:
-                    #        free_block_addr = page.freelist
-                    #        computed_size = 0
-                    #        while free_block_addr != 0x0 and computed_size < page.units:
-                    #            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
-                    #            if size_or_off > 0:
-                    #                size = size_or_off
-                    #                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
-                                    # print(off)
-                    #                block = self.addr_space.read(free_block_addr, size * slob_unit_size)
-                                    #for i in range(size * slob_unit_size / 4):
-                                    #    o = obj.Object('int', offset = free_block_addr + slob_unit_size + i * 4, vm = self.addr_space)
-                                        # print(self.addr_space)
-                                        # print(size)
-                                        # print(free_block_addr + slob_unit_size + i)
-                                    #print(block)
-                    #            else:
-                    #                size = 1
-                    #                off = -size_or_off
-                    #            computed_size += size
-                    #            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
-
                     if dump_list != None:
                         if dump_file != None:
                             dump = open(dump_file, "wb")

--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -17,19 +17,16 @@
 #
 
 """
-@author:       Joe Sylve
+@author:       SLAB: Joe Sylve; SLUB and SLOB: Fulvio Di Girolamo, Angelo Russi
 @license:      GNU General Public License 2.0
 @contact:      joe.sylve@gmail.com
 @organization: Digital Forensics Solutions
 """
 
 import volatility.obj as obj
-from volatility.obj import Pointer
 import volatility.debug as debug
 import volatility.plugins.linux.common as linux_common
 
-MAX_SLABS = 500
-MAX_ALIASES = 500
 MAX_NODES = 1024
 PAGE_SIZE = 4096
 
@@ -151,6 +148,17 @@ class LinuxKmemCacheOverlay(obj.ProfileModification):
 class linux_slabinfo(linux_common.AbstractLinuxCommand):
     """Mimics /proc/slabinfo on a running machine"""
 
+    def __init__(self, config, *args, **kwargs):
+        linux_common.AbstractLinuxCommand.__init__(self, config, *args, **kwargs)
+        self._config.add_option('PAGE_SIZE', short_option = 'p', default = 0x1000,
+                          help = '<SLOB ONLY>The page size of the analyzed system',
+                          action = 'store', type = 'int')
+        self._config.add_option('<SLOB ONLY>DUMP_FREE_LIST', short_option = 'L', default = None,
+                          help = 'Select the free list to dump: (s)mall, (m)edium, (l)arge or (a)ll',
+                          action = 'store', type = 'str')
+        self._config.add_option('<SLOB ONLY>DUMP_FILE', short_option = 'D', default = None, 
+                          help = 'When using -L specify the name of the dump file')
+
     def get_all_kmem_caches(self):
         linux_common.set_plugin_members(self)
         cache_chain = self.addr_space.profile.get_symbol("cache_chain")
@@ -164,8 +172,12 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
             caches = obj.Object("list_head", offset = slab_caches, vm = self.addr_space)
             listm = "list"
             ret = [cache for cache in caches.list_of_type("kmem_cache", listm)]
-        else:
-            debug.error("Unknown or unimplemented slab type.")
+        else: # slob
+            # debug.error("Unknown or unimplemented slab type.")
+            free_slob_small = self.addr_space.profile.get_symbol("free_slob_small")
+            free_slob_medium = self.addr_space.profile.get_symbol("free_slob_medium")
+            free_slob_large = self.addr_space.profile.get_symbol("free_slob_large")
+            ret [free_slob_small, free_slob_medium, free_slob_large]
 
         return ret
 
@@ -236,9 +248,9 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                     #     print (page.freelist)
                     # print (page.counters)
                     active_objs = page.counters
+                    num_objs = cache_node.total_objects.counter
                     active_slabs = cache_node.nr_slabs.counter
                     num_slabs = cache_node.nr_slabs.counter
-                    num_objs = cache_node.total_objects.counter
                     if num_slabs != 0:
                         pagesperslab = int(num_objs * object_size / num_slabs / PAGE_SIZE)
                         if (num_objs * object_size)%(num_slabs * PAGE_SIZE) != 0:
@@ -254,19 +266,207 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                             pagesperslab,
                             active_slabs,
                             num_slabs]
+                
+                else: # slob
+                    SLOB_BREAK1 = 256
+                    SLOB_BREAK2 = 1024
+
+                    # Set the size of a slob unit in bytes depending on the page size
+                    page_size = self._config.PAGE_SIZE
+                    dump_list = self._config.DUMP_FREE_LIST
+                    dump_file = self._config.DUMP_FILE
+                    #page_list = None
+                    if page_size <= 32767 * 2:
+                        slob_unit_size = 2
+                        size_type = "short"
+                    else:
+                        slob_unit_size = 4
+                    # Assuming that sizeof(int) = 4...
+                        size_type = "int"                    
+
+                    # Create the list_head objects
+                    slob_small = obj.Object("list_head", offset = free_slob_small, vm = self.addr_space)
+                    slob_medium = obj.Object("list_head", offset = free_slob_medium, vm = self.addr_space)
+                    slob_large = obj.Object("list_head", offset = free_slob_large, vm = self.addr_space)
+
+                    # Gather the pages on the lists
+                    small_pages = [slob for slob in slob_small.list_of_type("page", "slab_list")]
+                    medium_pages = [slob for slob in slob_medium.list_of_type("page", "slab_list")]
+                    large_pages = [slob for slob in slob_large.list_of_type("page", "slab_list")]
+
+                    #if(dump_list == 's'):
+                    #    page_list = small_pages
+                    #elif(dump_list == 'm'):
+                    #    page_list = medium_pages
+                    #elif(dump_list == 'l'):
+                    #    page_list = large_pages
+                    #if(page_list != None):
+                    #    for page in page_list:
+                    #        free_block_addr = page.freelist
+                    #        computed_size = 0
+                    #        while free_block_addr != 0x0 and computed_size < page.units:
+                    #            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
+                    #            if size_or_off > 0:
+                    #                size = size_or_off
+                    #                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
+                                    # print(off)
+                    #                block = self.addr_space.read(free_block_addr, size * slob_unit_size)
+                                    #for i in range(size * slob_unit_size / 4):
+                                    #    o = obj.Object('int', offset = free_block_addr + slob_unit_size + i * 4, vm = self.addr_space)
+                                        # print(self.addr_space)
+                                        # print(size)
+                                        # print(free_block_addr + slob_unit_size + i)
+                                    #print(block)
+                    #            else:
+                    #                size = 1
+                    #                off = -size_or_off
+                    #            computed_size += size
+                    #            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
+
+                    if dump_list != None:
+                        if dump_file != None:
+                            dump = open(dump_file, "wb")
+                    
+                    # Enumerate the content of free_slob_small
+                    range_counters = [0] * 4
+                    free_space = 0
+                    space_counter = 0
+                    for page in small_pages:
+                        free_block_addr = page.freelist
+                        computed_size = 0
+                        while free_block_addr != 0x0 and computed_size < page.units:
+                            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
+                            if size_or_off > 0:
+                                size = size_or_off
+                                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
+                                if (dump_list == "s" or dump_list == "a") and dump_file != None and size * slob_unit_size < SLOB_BREAK1:
+                                    block = self.addr_space.read(free_block_addr, size * slob_unit_size)
+                                    header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
+                                    header = header.encode('ascii')
+                                    dump.write(header)
+                                    dump.write(block)
+                                    dump.write(b'\n')
+                            else:
+                                size = 1
+                                off = -size_or_off
+                            computed_size += size
+                            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
+                            if size >= 256/slob_unit_size:
+                                continue
+                            free_space += size*slob_unit_size
+                            space_counter += 1
+                            range_counters[size/(64/slob_unit_size)] += 1
+                    yield("free_slob_small", "0-63", range_counters[0])
+                    yield("free_slob_small", "64-127", range_counters[1])
+                    yield("free_slob_small", "128-191", range_counters[2])
+                    yield("free_slob_small", "192-255", range_counters[3])
+                    print("------------ slob small stats -----------------")
+                    print("free space "+str(free_space)+" | free_mean_size "+str(free_space/space_counter)+" | PAGES "+str(len(small_pages)))
+                    print("-------------------- --------------- ----------")
+
+                    # Enumerate the content of free_slob_medium
+                    range_counters = [0] * 4
+                    free_space = 0
+                    space_counter = 0
+                    for page in medium_pages:
+                        free_block_addr = page.freelist
+                        computed_size = 0
+                        while free_block_addr != 0x0 and computed_size < page.units:
+                            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
+                            if size_or_off > 0:
+                                size = size_or_off
+                                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
+                                if (dump_list == "m" or dump_list == "a") and dump_file != None and size * slob_unit_size >= SLOB_BREAK1 and size * slob_unit_size < SLOB_BREAK2:
+                                    block = self.addr_space.read(free_block_addr, size * slob_unit_size)
+                                    header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
+                                    header = header.encode('ascii')
+                                    dump.write(header)
+                                    dump.write(block)
+                                    dump.write(b'\n')
+                            else:
+                                size = 1
+                                off = -size_or_off
+                            computed_size += size
+                            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
+                            if size >= 1024/slob_unit_size: 
+                                continue
+                            free_space += size*slob_unit_size
+                            space_counter += 1
+                            range_counters[size/(256/slob_unit_size)] += 1
+                    yield("free_slob_medium", "0-255", range_counters[0])
+                    yield("free_slob_medium", "256-511", range_counters[1])
+                    yield("free_slob_medium", "512-767", range_counters[2])
+                    yield("free_slob_medium", "768-1023", range_counters[3])
+                    print("------------ slob medium stats ----------------")
+                    print("free space "+str(free_space)+" | free_mean_size "+str(free_space/space_counter)+" | PAGES "+str(len(medium_pages)))
+                    print("-------------------- --------------- ----------")
+
+                    # Enumerate the content of free_slob_large
+                    range_counters = [0] * 5
+                    free_space = 0
+                    space_counter = 0
+                    base = self._config.PAGE_SIZE / 4
+                    for page in large_pages:
+                        free_block_addr = page.freelist
+                        computed_size = 0
+                        while free_block_addr != 0x0 and computed_size < page.units:
+                            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
+                            if size_or_off > 0:
+                                size = size_or_off
+                                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
+                                if (dump_list == "l" or dump_list == "a") and dump_file != None and size * slob_unit_size >= SLOB_BREAK2:
+                                    block = self.addr_space.read(free_block_addr, size * slob_unit_size)
+                                    header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
+                                    header = header.encode('ascii')
+                                    dump.write(header)
+                                    dump.write(block)
+                                    dump.write(b'\n')
+                            else:
+                                size = 1
+                                off = -size_or_off
+                            computed_size += size
+                            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
+                            if size >= page_size:
+                                range_counters[4] += 1
+                                continue
+                            free_space += size*slob_unit_size
+                            space_counter += 1
+                    range_counters[size/(base/slob_unit_size)] += 1
+                    yield("free_slob_large", "0-"+str(base-1), range_counters[0])
+                    yield("free_slob_large", str(base)+"-"+str(base*2-1), range_counters[1])
+                    yield("free_slob_large", str(base*2)+"-"+str(base*3-1), range_counters[2])
+                    yield("free_slob_large", str(base*3)+"-"+str(base*4-1), range_counters[3])
+                    if(range_counters[4]>0):
+                        print "free_slob_large      "+str(range_counters[4])+" greater than a page(!?) <maybe wrong PAGE_SIZE>"
+                    print("------------ slob large stats ----------------")
+                    print("free space "+str(free_space)+" | free_mean_size "+str(free_space/space_counter)+" | PAGES "+str(len(large_pages)))
+
+                    if dump_file != None:
+                        dump.close()
 
 
 
     def render_text(self, outfd, data):
-        self.table_header(outfd, [("<name>", "<30"),
-                                  ("<active_objs>", "<13"),
-                                  ("<num_objs>", "<10"),
-                                  ("<objsize>", "<10"),
-                                  ("<objperslab>", "<12"),
-                                  ("<pagesperslab>", "<15"),
-                                  ("<active_slabs>", "<14"),
-                                  ("<num_slabs>", "<7"),
-                                  ])
+        cache_chain = self.addr_space.profile.get_symbol("cache_chain")
+        slab_caches = self.addr_space.profile.get_symbol("slab_caches")
+        if cache_chain or slab_caches:
+            self.table_header(outfd, [("<name>", "<30"),
+                                    ("<active_objs>", "<13"),
+                                    ("<num_objs>", "<10"),
+                                    ("<objsize>", "<10"),
+                                    ("<objperslab>", "<12"),
+                                    ("<pagesperslab>", "<15"),
+                                    ("<active_slabs>", "<14"),
+                                    ("<num_slabs>", "<7"),
+                                    ])
 
-        for info in data:
-            self.table_row(outfd, info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7])
+            for info in data:
+                self.table_row(outfd, info[0], info[1], info[2], info[3], info[4], info[5], info[6], info[7])
+        else: #slob
+            self.table_header(outfd, [("<list_name>", "<20"),
+                                  ("<range (bytes)>", "<10"),
+                                  ("<# free>", "<10")
+                                 ])
+
+            for info in data:
+                self.table_row(outfd, info[0], info[1], info[2])

--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -174,8 +174,8 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
             listm = "next"
             ret = [cache for cache in caches.list_of_type("kmem_cache", listm)]
         elif slob_list : #slob
-            obj = kmem_cache_slob()
-            ret = [obj]
+            slob = kmem_cache_slob()
+            ret = [slob]
         else: # slub
             caches = obj.Object("list_head", offset = slab_caches, vm = self.addr_space)
             listm = "list"
@@ -260,7 +260,7 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                             active_objs,
                             num_objs,
                             object_size,
-                            objperslabs,
+                            objperslab,
                             pagesperslab,
                             active_slabs,
                             num_slabs]

--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -246,6 +246,7 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                     #print cache_node.nr_partial
                     #print hex(cache_node.partial.next)
                     page = obj.Object('page', offset = cache_node.partial.next, vm = self.addr_space)
+                    print page.inuse
                     #print page.objects - page.inuse
                     #for i in node:
                     #    cache_node = obj.Object('kmem_cache_node', offset = i, vm = self.addr_space)
@@ -268,7 +269,8 @@ class linux_slabinfo(linux_common.AbstractLinuxCommand):
                     #    print page.counters / page.index
                     #print page.pages
                     #print page.pobjects
-                    #page2 = obj.Object('page', offset = page.next, vm = self.addr_space)
+                    page2 = obj.Object('page', offset = page.next, vm = self.addr_space)
+                    print page2.inuse
                     #print page2.counters
                     #print page2.inuse
                     #print page2.freelist

--- a/volatility/plugins/linux/slab_info.py
+++ b/volatility/plugins/linux/slab_info.py
@@ -124,14 +124,6 @@ class kmem_cache_slub(kmem_cache):
 
     def get_size(self):
         return int(self.size())
-    
-    def get_nodes(self):
-        off = self.cpu_slab
-        inuse = self.size
-        print("nodes offset"+str(off))
-        print("size "+str(inuse))
-        nodes = obj.Array("kmem_cache_node", offset=self.node.dereference(), vm = self.obj_vm)
-        return nodes
 
 class kmem_cache_slob():
 

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -131,7 +131,7 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                     off = -size_or_off
                 computed_size += size
                 free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
-		        if size >= 256/slob_unit_size:
+                if size >= 256/slob_unit_size:
                     continue
                 free_space += size*slob_unit_size
                 space_counter += 1

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -1,3 +1,27 @@
+# Volatility
+#
+# This file is part of Volatility.
+#
+# Volatility is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Volatility is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Volatility.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+@author:       Fulvio Di Girolamo - Angelo Russi
+@license:      GNU General Public License 2.0
+
+"""
+
 import volatility.obj as obj
 import volatility.debug as debug
 import volatility.plugins.linux.common as linux_common
@@ -107,7 +131,7 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                     off = -size_or_off
                 computed_size += size
                 free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
-		if size >= 256/slob_unit_size:
+		        if size >= 256/slob_unit_size:
                     continue
                 free_space += size*slob_unit_size
                 space_counter += 1

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -1,0 +1,45 @@
+import volatility.obj as obj
+import volatility.debug as debug
+import volatility.plugins.linux.common as linux_common
+
+class linux_slobinfo(linux_common.AbstractLinuxCommand):
+    def calculate(self):
+        linux_common.set_plugin_members(self)
+
+        free_slob_small = self.addr_space.profile.get_symbol("free_slob_small")
+        free_slob_medium = self.addr_space.profile.get_symbol("free_slob_medium")
+        free_slob_large = self.addr_space.profile.get_symbol("free_slob_large")
+        slob_small = obj.Object("list_head", offset = free_slob_small, vm = self.addr_space)
+        slob_medium = obj.Object("list_head", offset = free_slob_medium, vm = self.addr_space)
+        slob_large = obj.Object("list_head", offset = free_slob_large, vm = self.addr_space)
+        slobs = [slob for slob in slob_small.list_of_type("page", "slab_list")]
+        print 'slob 0 s_mem ' + hex(slobs[0].s_mem)
+        print 'slob 1 s_mem ' + hex(slobs[1].s_mem)
+        print 'slob 2 s_mem ' + hex(slobs[2].s_mem)
+        print 'slob 3 s_mem ' + hex(slobs[3].s_mem)
+        print 'slob 1 addr '  + hex(slobs[0].slab_list.next)
+        print 'slob 2 addr '  + hex(slobs[1].slab_list.next)
+        print 'slob 1 units '  + hex(slobs[1].units)
+        print 'slob 0 units ' + hex(slobs[0].units)
+        print 'slob 2 units ' + hex(slobs[2].units)
+        print 'slob 0 freelist ' + hex(slobs[0].freelist)
+        print 'slob 1 freelist ' + hex(slobs[1].freelist)
+        print 'slob 2 freelist ' + hex(slobs[2].freelist)
+        size = obj.Object('short', offset = slobs[0].freelist, vm = self.addr_space)
+        print size
+        off = obj.Object('short', offset = slobs[0].freelist + 2, vm = self.addr_space)
+        print off
+        size = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2, vm = self.addr_space)
+        print size
+        off = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2 + 2, vm = self.addr_space)
+        print off
+        size = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2, vm = self.addr_space)
+        print size
+        print len(slobs)
+        yield(1)
+
+    def render_text(self, outfd, data):
+        self.table_header(outfd, [("<name>", "<30")])
+
+        for info in data:
+            self.table_row(outfd, info)

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -74,35 +74,6 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
         medium_pages = [slob for slob in slob_medium.list_of_type("page", "slab_list")]
         large_pages = [slob for slob in slob_large.list_of_type("page", "slab_list")]
 
-        #if(dump_list == 's'):
-        #    page_list = small_pages
-        #elif(dump_list == 'm'):
-        #    page_list = medium_pages
-        #elif(dump_list == 'l'):
-        #    page_list = large_pages
-        #if(page_list != None):
-        #    for page in page_list:
-        #        free_block_addr = page.freelist
-        #        computed_size = 0
-        #        while free_block_addr != 0x0 and computed_size < page.units:
-        #            size_or_off = obj.Object(size_type, offset = free_block_addr, vm = self.addr_space)
-        #            if size_or_off > 0:
-        #                size = size_or_off
-        #                off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
-                        # print(off)
-        #                block = self.addr_space.read(free_block_addr, size * slob_unit_size)
-                        #for i in range(size * slob_unit_size / 4):
-                        #    o = obj.Object('int', offset = free_block_addr + slob_unit_size + i * 4, vm = self.addr_space)
-                            # print(self.addr_space)
-                            # print(size)
-                            # print(free_block_addr + slob_unit_size + i)
-                        #print(block)
-        #            else:
-        #                size = 1
-        #                off = -size_or_off
-        #            computed_size += size
-        #            free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
-
         if dump_list != None:
             if dump_file != None:
                 dump = open(dump_file, "wb")

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -11,13 +11,16 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                           help = 'The page size of the analyzed system',
                           action = 'store', type = 'int')
         self._config.add_option('DUMP_FREE_LIST', short_option = 'L', default = None,
-                          help = 'Select the free list to dump: (s)mall, (m)edium or (l)arge',
+                          help = 'Select the free list to dump: (s)mall, (m)edium, (l)arge or (a)ll',
                           action = 'store', type = 'str')
         self._config.add_option('DUMP_FILE', short_option = 'D', default = None, 
                           help = 'When using -L specify the name of the dump file')
 
     def calculate(self):
         linux_common.set_plugin_members(self)
+
+        SLOB_BREAK1 = 256
+        SLOB_BREAK2 = 1024
 
         # Set the size of a slob unit in bytes depending on the page size
         page_size = self._config.PAGE_SIZE
@@ -92,7 +95,7 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                 if size_or_off > 0:
                     size = size_or_off
                     off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
-                    if dump_list == "s" and dump_file != None:
+                    if (dump_list == "s" or dump_list == "a") and dump_file != None and size * slob_unit_size < SLOB_BREAK1:
                         block = self.addr_space.read(free_block_addr, size * slob_unit_size)
                         header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
                         header = header.encode('ascii')
@@ -129,7 +132,7 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                 if size_or_off > 0:
                     size = size_or_off
                     off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
-                    if dump_list == "m" and dump_file != None:
+                    if (dump_list == "m" or dump_list == "a") and dump_file != None and size * slob_unit_size >= SLOB_BREAK1 and size * slob_unit_size < SLOB_BREAK2:
                         block = self.addr_space.read(free_block_addr, size * slob_unit_size)
                         header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
                         header = header.encode('ascii')
@@ -167,7 +170,7 @@ class linux_slobinfo(linux_common.AbstractLinuxCommand):
                 if size_or_off > 0:
                     size = size_or_off
                     off = obj.Object(size_type, offset = free_block_addr + slob_unit_size, vm = self.addr_space)
-                    if dump_list == 'l' and dump_file != None:
+                    if (dump_list == "l" or dump_list == "a") and dump_file != None and size * slob_unit_size >= SLOB_BREAK2:
                         block = self.addr_space.read(free_block_addr, size * slob_unit_size)
                         header = 'Address: ' + hex(free_block_addr) + ', Size: ' + str(size * slob_unit_size) + '\n'
                         header = header.encode('ascii')

--- a/volatility/plugins/linux/slob_info.py
+++ b/volatility/plugins/linux/slob_info.py
@@ -3,39 +3,52 @@ import volatility.debug as debug
 import volatility.plugins.linux.common as linux_common
 
 class linux_slobinfo(linux_common.AbstractLinuxCommand):
+    """Information about the status of the SLOB allocator"""
+
+    def __init__(self, config, *args, **kwargs):
+        linux_common.AbstractLinuxCommand.__init__(self, config, *args, **kwargs)
+        config.add_option('PAGE_SIZE', short_option = 'p', default = 0x1000,
+                          help = 'The page size of the analyzed system',
+                          action = 'store', type = 'int')
+
     def calculate(self):
         linux_common.set_plugin_members(self)
 
+        # Set the size of a slob unit in bytes depending on the page size
+        page_size = self._config.PAGE_SIZE
+        if page_size <= 32767 * 2:
+            slob_unit_size = 2
+        else:
+            slob_unit_size = 4
+
+        # Find offsets of the 3 list_head objects for the SLOB page lists
         free_slob_small = self.addr_space.profile.get_symbol("free_slob_small")
         free_slob_medium = self.addr_space.profile.get_symbol("free_slob_medium")
         free_slob_large = self.addr_space.profile.get_symbol("free_slob_large")
+
+        # Create the list_head objects
         slob_small = obj.Object("list_head", offset = free_slob_small, vm = self.addr_space)
         slob_medium = obj.Object("list_head", offset = free_slob_medium, vm = self.addr_space)
         slob_large = obj.Object("list_head", offset = free_slob_large, vm = self.addr_space)
-        slobs = [slob for slob in slob_small.list_of_type("page", "slab_list")]
-        print 'slob 0 s_mem ' + hex(slobs[0].s_mem)
-        print 'slob 1 s_mem ' + hex(slobs[1].s_mem)
-        print 'slob 2 s_mem ' + hex(slobs[2].s_mem)
-        print 'slob 3 s_mem ' + hex(slobs[3].s_mem)
-        print 'slob 1 addr '  + hex(slobs[0].slab_list.next)
-        print 'slob 2 addr '  + hex(slobs[1].slab_list.next)
-        print 'slob 1 units '  + hex(slobs[1].units)
-        print 'slob 0 units ' + hex(slobs[0].units)
-        print 'slob 2 units ' + hex(slobs[2].units)
-        print 'slob 0 freelist ' + hex(slobs[0].freelist)
-        print 'slob 1 freelist ' + hex(slobs[1].freelist)
-        print 'slob 2 freelist ' + hex(slobs[2].freelist)
-        size = obj.Object('short', offset = slobs[0].freelist, vm = self.addr_space)
-        print size
-        off = obj.Object('short', offset = slobs[0].freelist + 2, vm = self.addr_space)
-        print off
-        size = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2, vm = self.addr_space)
-        print size
-        off = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2 + 2, vm = self.addr_space)
-        print off
-        size = obj.Object('short', offset = (slobs[0].freelist & 0xfffffffffffff000) + off*2, vm = self.addr_space)
-        print size
-        print len(slobs)
+
+        # Gather the pages on the free_slob_small list
+        small_pages = [slob for slob in slob_small.list_of_type("page", "slab_list")]
+        
+        # First free object size/offset
+        for page in small_pages:
+            free_block_addr = page.freelist
+            computed_size = 0
+            while free_block_addr != 0x0 and computed_size < page.units:
+                size_or_off = obj.Object('short', offset = free_block_addr, vm = self.addr_space)
+                if size_or_off > 0:
+                    size = size_or_off
+                    off = obj.Object('short', offset = free_block_addr + slob_unit_size, vm = self.addr_space)
+                else:
+                    size = 1
+                    off = -size_or_off
+                computed_size += size
+                free_block_addr = free_block_addr - free_block_addr % page_size + off * 2
+        print len(small_pages)
         yield(1)
 
     def render_text(self, outfd, data):


### PR DESCRIPTION
We introduce the `linux_slobinfo` plugin, which allows to analyze the status of the SLOB memory allocator by providing:  
1. Summary information about the free lists (small, medium, large)
2. An option to dump the contents of one or all the free lists to file.

The same functionality is also included in the `linux_slabinfo` plugin and automatically invoked if the presence of the SLOB allocator is detected from the memory dump.

Additionally, we introduce in the `linux slabinfo` plugin a functionality for the analysis of the status of the SLUB memory allocator which provides summary information about the caches (corresponding to the information provided by the `slabinfo` command) and is automatically invoked if the presence of SLUB is detected from the memory dump. 

NOTE: The SLUB analysis functionality is at the moment only partial and heavily dependent on the specific version of the Linux kernel being used, due to the fact that when attempting to extract Volatility profiles from the system while using more recent versions we obtained profiles missing the definition of some key data structures (we assumed this to be a limitation of the tool used to extract profiles). In particular, we tested on kernel version 3.5.7. For more information, we join a complete `.pdf` report of our work ([Report.pdf](https://github.com/volatilityfoundation/volatility/files/6861377/Report.pdf)).