### PR TITLE
Add GPL-license to module.c

### DIFF
--- a/tools/linux/module.c
+++ b/tools/linux/module.c
@@ -5,6 +5,8 @@ symbols and then read the DWARF symbols from it.
 #include <linux/module.h>
 #include <linux/version.h>
 
+MODULE_LICENSE("GPL");
+
 #include <linux/ioport.h>
 #include <linux/fs_struct.h>
 #include <linux/fs.h>


### PR DESCRIPTION
Without having added a license to `module.c`, the following error frequently occurs:
```
ERROR: modpost: missing MODULE_LICENSE() in .../volatility/tools/linux/module.o
```

This PR resolves #803 and resolves #812