### PR TITLE
Allow building from custom sources

### DIFF
--- a/tools/linux/Makefile
+++ b/tools/linux/Makefile
@@ -1,13 +1,28 @@
 obj-m += module.o
-KDIR ?= /
 KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVER)/build
+PREFIX ?= /
+
+# Example                                                                                                                                                                                                          
+# Make module for currently running kernel:                                                                                                                                                                        
+#     make                                                                                                                                                                                                         
+#                                                                                                                                                                                                                  
+# Make module for other kernel installed locally.                                                                                                                                                                  
+#     make KVER=3.10.0-862.14.4.el7.x86_64                                                                                                                                                                         
+#                                                                                                                                                                                                                  
+# Make module for kernel which is not installed, but are installed kernel headers from kernel-devel                                                                                                                 
+#     make KVER=3.10.0-862.14.4.el7.x86_64 KDIR=/usr/src/kernels/3.10.0-862.14.4.el7.x86_64                                                                                                                        
+#                                                                                                                                                                                                                  
+# Make module for custom kernel source                                                                                                                                                                             
+#     make KVER=6.1.0-orion  KDIR=/home/example/src/kernel-6.1.0                                                                                                                                                   
+#                                                       
 
 -include version.mk
 
 all: dwarf 
 
 dwarf: module.c
-	$(MAKE) -C $(KDIR)/lib/modules/$(KVER)/build CONFIG_DEBUG_INFO=y M="$(PWD)" modules
+	$(MAKE) V=1 -C $(KDIR) CONFIG_DEBUG_INFO=y M="$(PWD)" modules
 	dwarfdump -di module.ko > module.dwarf
 	$(MAKE) -C $(KDIR)/lib/modules/$(KVER)/build M="$(PWD)" clean
 


### PR DESCRIPTION
Change the default definition of the KDIR from being just a prefix to full path to the kernel headers allows to override this value and compile the module using arbitrary location of the kernel headers or full source code.

Added also some common usage examples in the comment.

Adding the PREFIX variable might serve the original prefix purpose of the KDIR if somebody needs such functionality in some mass module rebuilding scripts