### PR TITLE
Update Linux DTB scanner to handle newer Linux kernel versions (>= 5.14-rc1)

### DIFF
--- a/volatility/plugins/overlays/linux/linux.py
+++ b/volatility/plugins/overlays/linux/linux.py
@@ -2368,7 +2368,7 @@ class VolatilityDTB(obj.VolatilityMagic):
         try:
             # For Linux kernels < v5.14-rc1
             state_offset  = profile.get_obj_offset("task_struct", "state")
-        except:
+        except KeyError:
             # For Linux kernels >= v5.14-rc1, based on commit 2f064a59a11ff9bc22e52e9678bc601404c7cb34
             state_offset  = profile.get_obj_offset("task_struct", "__state")
         


### PR DESCRIPTION
Since commit 2f064a5 in the Linux kernel (5.14-rc1) the task state field is no longer called "state" but is instead called "__state".

This commit adds support to first look for "state" and if that is not found, attempt to look for the "__state" field.

This should resolve issues some folks been having with newer Linux kernel releases.