### PR TITLE
Add MODULE_LICENSE to Linux kernel module used for profile creation

### DIFF
--- a/tools/linux/module.c
+++ b/tools/linux/module.c
@@ -627,4 +627,6 @@ struct mount {
 #endif
 
 struct resource resource;
-
+#ifdef MODULE_LICENSE
+MODULE_LICENSE("GPL");
+#endif


### PR DESCRIPTION
In order to build a Linux kernel module a MODULE_LICENSE tag is required.

The MODULE_LICENSE tag specifies the license of the kernel module.